### PR TITLE
Changes to be compatible with arcdps mock

### DIFF
--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -1,3 +1,4 @@
+#define IMGUI_DEFINE_MATH_OPERATORS
 #include "Widgets.h"
 
 #include <cstdlib>

--- a/arcdps_structs.cpp
+++ b/arcdps_structs.cpp
@@ -1,7 +1,7 @@
 #include "arcdps_structs.h"
 
+#ifndef ARCDPS_EXTENSION_NO_LANG_H
 #include "../Lang.h"
-
 std::string to_string(Alignment alignment) {
 	switch (alignment) {
 	case Alignment::Left: return lang.translate(LangKey::Left);
@@ -11,6 +11,7 @@ std::string to_string(Alignment alignment) {
 	default: return "Unknown";
 	}
 }
+#endif
 
 bool is_player(ag* new_player)
 {

--- a/arcdps_structs.h
+++ b/arcdps_structs.h
@@ -173,11 +173,11 @@ typedef struct ag {
 
 bool is_player(ag* new_player);
 
-typedef uintptr_t(*WindowCallbackSignature)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-typedef uintptr_t(*CombatCallbackSignature)(cbtevent* ev, ag* src, ag* dst, const char* skillname, uint64_t id, uint64_t revision);
-typedef uintptr_t(*ImguiCallbackSignature)(uint32_t not_charsel_or_loading);
-typedef uintptr_t(*OptionsEndCallbackSignature)();
-typedef uintptr_t(*OptionsWindowsCallbackSignature)(const char* windowname);
+typedef uintptr_t (*WindowCallbackSignature)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+typedef uintptr_t (*CombatCallbackSignature)(cbtevent* ev, ag* src, ag* dst, const char* skillname, uint64_t id, uint64_t revision);
+typedef uintptr_t (*ImguiCallbackSignature)(uint32_t not_charsel_or_loading);
+typedef uintptr_t (*OptionsEndCallbackSignature)();
+typedef uintptr_t (*OptionsWindowsCallbackSignature)(const char* windowname);
 
 typedef struct arcdps_exports {
 	uintptr_t size; /* size of exports table */
@@ -194,6 +194,17 @@ typedef struct arcdps_exports {
 	OptionsWindowsCallbackSignature options_windows; /* called once per 'window' option checkbox, with null at the end, non-zero return disables drawing that option, fn(char* windowname) */
 } arcdps_exports;
 static_assert(sizeof(arcdps_exports) == 88, "");
+
+typedef void* (*MallocSignature)(size_t);
+typedef void (*FreeSignature)(void*);
+
+typedef arcdps_exports* (*ModInitSignature)();
+typedef uintptr_t (*ModReleaseSignature)();
+
+struct IDirect3DDevice9;
+struct ImGuiContext;
+typedef ModInitSignature (*GetInitAddrSignature)(const char* arcversion, ImGuiContext* imguictx, IDirect3DDevice9* id3dd9, HMODULE arcdll, MallocSignature mallocfn, FreeSignature freefn);
+typedef ModReleaseSignature (*GetReleaseAddrSignature)();
 
 // additional enum for alignment
 enum class Alignment {

--- a/arcdps_structs.h
+++ b/arcdps_structs.h
@@ -163,7 +163,7 @@ typedef struct cbtevent {
 
 /* agent short */
 typedef struct ag {
-	char* name; /* agent name. may be null. valid only at time of event. utf8 */
+	const char* name; /* agent name. may be null. valid only at time of event. utf8 */
 	uintptr_t id; /* agent unique identifier */
 	Prof prof; /* profession at time of event. refer to evtc notes for identification */
 	uint32_t elite; /* elite spec at time of event. refer to evtc notes for identification */

--- a/arcdps_structs.h
+++ b/arcdps_structs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <Windows.h>
 
 //enums and structs:
 /* is friend/foe */
@@ -130,21 +131,6 @@ enum ColorsCore {
 	CCOL_NUM
 };
 
-typedef struct arcdps_exports {
-	uintptr_t size; /* size of exports table */
-	uint32_t sig; /* pick a number between 0 and uint32_t max that isn't used by other modules */
-	uint32_t imguivers; /* set this to IMGUI_VERSION_NUM. if you don't use imgui, 18000 (as of 2021-02-02) */
-	const char* out_name; /* name string */
-	const char* out_build; /* build string */
-	void* wnd_nofilter; /* wndproc callback, fn(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) */
-	void* combat; /* combat event callback, fn(cbtevent* ev, ag* src, ag* dst, char* skillname, uint64_t id, uint64_t revision) */
-	void* imgui; /* id3dd9::present callback, before imgui::render, fn(uint32_t not_charsel_or_loading) */
-	void* options_end; /* id3dd9::present callback, appending to the end of options window in arcdps, fn() */
-	void* combat_local;  /* combat event callback like area but from chat log, fn(cbtevent* ev, ag* src, ag* dst, char* skillname, uint64_t id, uint64_t revision) */
-	void* wnd_filter; /* wndproc callback like above, input filered using modifiers */
-	void* options_windows; /* called once per 'window' option checkbox, with null at the end, non-zero return disables drawing that option, fn(char* windowname) */
-} arcdps_exports;
-
 typedef struct cbtevent {
 	uint64_t time;
 	uintptr_t src_agent;
@@ -186,6 +172,28 @@ typedef struct ag {
 } ag;
 
 bool is_player(ag* new_player);
+
+typedef uintptr_t(*WindowCallbackSignature)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+typedef uintptr_t(*CombatCallbackSignature)(cbtevent* ev, ag* src, ag* dst, const char* skillname, uint64_t id, uint64_t revision);
+typedef uintptr_t(*ImguiCallbackSignature)(uint32_t not_charsel_or_loading);
+typedef uintptr_t(*OptionsEndCallbackSignature)();
+typedef uintptr_t(*OptionsWindowsCallbackSignature)(const char* windowname);
+
+typedef struct arcdps_exports {
+	uintptr_t size; /* size of exports table */
+	uint32_t sig; /* pick a number between 0 and uint32_t max that isn't used by other modules */
+	uint32_t imguivers; /* set this to IMGUI_VERSION_NUM. if you don't use imgui, 18000 (as of 2021-02-02) */
+	const char* out_name; /* name string */
+	const char* out_build; /* build string */
+	WindowCallbackSignature wnd_nofilter; /* wndproc callback, fn(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) */
+	CombatCallbackSignature combat; /* combat event callback, fn(cbtevent* ev, ag* src, ag* dst, char* skillname, uint64_t id, uint64_t revision) */
+	ImguiCallbackSignature imgui; /* id3dd9::present callback, before imgui::render, fn(uint32_t not_charsel_or_loading) */
+	OptionsEndCallbackSignature options_end; /* id3dd9::present callback, appending to the end of options window in arcdps, fn() */
+	CombatCallbackSignature combat_local;  /* combat event callback like area but from chat log, fn(cbtevent* ev, ag* src, ag* dst, char* skillname, uint64_t id, uint64_t revision) */
+	WindowCallbackSignature wnd_filter; /* wndproc callback like above, input filered using modifiers */
+	OptionsWindowsCallbackSignature options_windows; /* called once per 'window' option checkbox, with null at the end, non-zero return disables drawing that option, fn(char* windowname) */
+} arcdps_exports;
+static_assert(sizeof(arcdps_exports) == 88, "");
 
 // additional enum for alignment
 enum class Alignment {


### PR DESCRIPTION
- Types for all(?) function pointers
- const qualifier on a couple of char* arguments
- define IMGUI_DEFINE_MATH_OPERATORS in Widgets.cpp so it doesn't have to be defined project wide
- add check for ARCDPS_EXTENSION_NO_LANG_H which can be defined in case there is no Lang.h available (to_string(Alignment) is not usable with it defined)