### PR TITLE
UpdateCheckerBase improvements

### DIFF
--- a/UpdateCheckerBase.cpp
+++ b/UpdateCheckerBase.cpp
@@ -1,13 +1,11 @@
 #include "UpdateCheckerBase.h"
 
+#include <charconv>
 #include <optional>
 #include <thread>
 #include <sstream>
 
 #include "json.hpp"
-bool compareFloat(float x, float y, float epsilon = FLT_EPSILON) {
-	return std::abs(x - y) < epsilon;
-}
 
 void UpdateCheckerBase::ClearFiles(HMODULE dll) {
 	CHAR dllPath[MAX_PATH] = { 0 };
@@ -73,56 +71,86 @@ std::string UpdateCheckerBase::GetVersionAsString(HMODULE dll) {
 }
 
 #ifndef ARCDPS_EXTENSION_NO_CPR
+#pragma warning(push)
+#pragma warning(disable: 4996) //  error C4996: '_Header_cstdbool': warning STL4004: <ccomplex>, <cstdalign>, <cstdbool>, and <ctgmath> are deprecated in C++17.
 #include <cpr/cpr.h>
+#pragma warning(pop)
 
-void UpdateCheckerBase::CheckForUpdate(HMODULE dll, std::string repo) {
-	auto currentVersion = GetCurrentVersion(dll);
-	if (!currentVersion) return;
-	version = currentVersion.value();
+void UpdateCheckerBase::CheckForUpdate(Version currentVersion, std::string repo, bool allowPrerelease) {
+	version = currentVersion;
 
-	std::thread cprCall([this, repo]() {
-		std::string link = "https://api.github.com/repos/";
-		link.append(repo);
-		link.append("/releases/latest");
+	std::thread cprCall([this, repo, allowPrerelease]() {
+		nlohmann::basic_json<> json;
+		nlohmann::basic_json<>* release;
+		if (!allowPrerelease)
+		{
+			std::string link = "https://api.github.com/repos/";
+			link.append(repo);
+			link.append("/releases/latest");
 
-		cpr::Response response = cpr::Get(cpr::Url{ link });
-
-		if (response.status_code == 200) {
-			auto json = nlohmann::json::parse(response.text);
-
-			std::string tagName = json.at("tag_name").get<std::string>();
-			if (tagName[0] == 'v') {
-				tagName.erase(0, 1);
-			}
-
-			std::vector<std::string> versionNums;
-			std::istringstream iss(tagName);
-
-			for (std::string token; std::getline(iss, token, '.'); )
+			auto response = HttpGet(link);
+			if (!response.has_value())
 			{
-				versionNums.push_back(std::move(token));
+				return;
 			}
 
-			// TODO: use semver to calculate this. So all semver releases can be parsed and not only my hardcoded ones :)
-			// libary for it: https://github.com/Neargye/semver
-			
-			if (versionNums.size() < 3) return;
+			json = nlohmann::json::parse(response.value());
+			release = &json;
+		}
+		else
+		{
+			std::string link = "https://api.github.com/repos/";
+			link.append(repo);
+			link.append("/releases");
 
-			newVersion[0] = std::stof(versionNums[0]);
-			newVersion[1] = std::stof(versionNums[1]);
-			newVersion[2] = std::stof(versionNums[2]);
-
-			if (newVersion[0] > version[0] || newVersion[1] > version[1] || newVersion[2] > version[2]) {
-				Status expected = Status::Unknown;
-				update_status.compare_exchange_strong(expected, Status::UpdateAvailable);
+			auto response = HttpGet(link);
+			if (!response.has_value())
+			{
+				return;
 			}
 
-			// load download URL
-			downloadUrl = json["assets"][0]["browser_download_url"].get<std::string>();
+			json = nlohmann::json::parse(response.value());
+			release = &json[0];
+		}
+
+		const auto tagName = release->at("tag_name").get<std::string>();
+		newVersion = ParseVersion(tagName);
+
+		// load download URL (use the first asset that has a .dll ending)
+		for (const auto& item : (*release)["assets"])
+		{
+			const auto assetName = item["name"].get<std::string>();
+			if (assetName.size() < 4)
+			{
+				continue;
+			}
+
+			if (std::string_view(assetName).substr(assetName.size() - 4) == ".dll")
+			{
+				downloadUrl = item["browser_download_url"].get<std::string>();
+				//LogD("Found download url in {} - {}", assetName, downloadUrl);
+			}
+		}
+
+		if (IsNewer(newVersion, version)) {
+			Status expected = Status::Unknown;
+			update_status.compare_exchange_strong(expected, Status::UpdateAvailable);
 		}
 	});
 
 	cprCall.detach();
+}
+
+std::optional<std::string> UpdateCheckerBase::HttpGet(const std::string& url)
+{
+	cpr::Response response = cpr::Get(cpr::Url{ url });
+
+	if (response.status_code != 200) {
+		//LogD("Getting {} failed {} {}", url, response.status_code, response.status_line);
+		return std::nullopt;
+	}
+
+	return response.text;
 }
 
 void UpdateCheckerBase::UpdateAutomatically(HMODULE dll) {
@@ -178,4 +206,74 @@ void UpdateCheckerBase::UpdateAutomatically(HMODULE dll) {
 	t.detach();
 }
 
-#endif
+bool UpdateCheckerBase::IsNewer(const Version& repoVersion, const Version& currentVersion)
+{
+	return std::tie(currentVersion[0], currentVersion[1], currentVersion[2])
+	     < std::tie(repoVersion[0], repoVersion[1], repoVersion[2]);
+}
+
+UpdateCheckerBase::Version UpdateCheckerBase::ParseVersion(std::string_view versionString)
+{
+	// TODO: use semver to calculate this. So all semver releases can be parsed and not only my hardcoded ones :)
+	// libary for it: https://github.com/Neargye/semver
+
+	Version result{};
+
+	if (versionString[0] == 'v') {
+		versionString = versionString.substr(1);
+	}
+
+	size_t tokenIndex = 0;
+	size_t start = 0;
+	do
+	{
+		size_t dotPos = versionString.find('.', start);
+		if (dotPos == std::string_view::npos)
+		{
+			dotPos = versionString.size();
+		}
+			
+		std::string_view token_str = versionString.substr(start, dotPos - start);
+
+		// Remove all non-digit characters from the beginning of the token
+		while (true)
+		{
+			if (token_str.empty())
+			{
+				break;
+			}
+			if (isdigit(*token_str.begin()))
+			{
+				break;
+			}
+			token_str = token_str.substr(1);
+		}
+
+		// Parse the str token to an integer
+		const auto from_chars_result = std::from_chars(
+			token_str.data(),
+			token_str.data() + token_str.size(),
+			result[tokenIndex]);
+		if (from_chars_result.ec != std::errc{})
+		{
+			//LogD("Parsing version token '{}' from '{}' failed", versionString, token_str);
+		}
+		else
+		{
+			tokenIndex++;
+		}
+
+		start = dotPos + 1; // + 1 to skip over the '.'
+	} while(start < versionString.size() && tokenIndex < 3);
+	
+	if (tokenIndex < 3)
+	{
+		//LogD("Failed to parse version from {} - only found {} tokens", versionString, tokenIndex);
+		return Version{};
+	}
+
+	return result;
+}
+
+
+#endif // ARCDPS_EXTENSION_NO_CPR

--- a/UpdateCheckerBase.cpp
+++ b/UpdateCheckerBase.cpp
@@ -10,172 +10,172 @@ bool compareFloat(float x, float y, float epsilon = FLT_EPSILON) {
 }
 
 void UpdateCheckerBase::ClearFiles(HMODULE dll) {
-    CHAR dllPath[MAX_PATH] = { 0 };
-    if (GetModuleFileNameA(dll, dllPath, _countof(dllPath)) == 0) {
-        return;
-    }
+	CHAR dllPath[MAX_PATH] = { 0 };
+	if (GetModuleFileNameA(dll, dllPath, _countof(dllPath)) == 0) {
+		return;
+	}
 
-    std::string dllPathTemp(dllPath);
-    dllPathTemp.append(".tmp");
+	std::string dllPathTemp(dllPath);
+	dllPathTemp.append(".tmp");
 
-    std::remove(dllPathTemp.c_str());
+	std::remove(dllPathTemp.c_str());
 
-    std::string dllPathOld(dllPath);
-    dllPathOld.append(".old");
+	std::string dllPathOld(dllPath);
+	dllPathOld.append(".old");
 
-    std::remove(dllPathOld.c_str());
+	std::remove(dllPathOld.c_str());
 }
 
 std::optional<UpdateCheckerBase::Version> UpdateCheckerBase::GetCurrentVersion(HMODULE dll) {
-    // GetModuleFileName
-    TCHAR moduleFileName[MAX_PATH + 1]{ };
-    if (!GetModuleFileName(dll, moduleFileName, MAX_PATH)) {
-        return std::nullopt;
-    }
+	// GetModuleFileName
+	TCHAR moduleFileName[MAX_PATH + 1]{ };
+	if (!GetModuleFileName(dll, moduleFileName, MAX_PATH)) {
+		return std::nullopt;
+	}
 
-    // GetFileVersionInfoSize
-    DWORD dummy; // this will get set to 0 (wtf windows api)
-    DWORD versionInfoSize = GetFileVersionInfoSize(moduleFileName, &dummy);
-    if (versionInfoSize == 0) {
-        return std::nullopt;
-    }
-    std::vector<BYTE> data(versionInfoSize);
+	// GetFileVersionInfoSize
+	DWORD dummy; // this will get set to 0 (wtf windows api)
+	DWORD versionInfoSize = GetFileVersionInfoSize(moduleFileName, &dummy);
+	if (versionInfoSize == 0) {
+		return std::nullopt;
+	}
+	std::vector<BYTE> data(versionInfoSize);
 
-    // GetFileVersionInfo
-    if (!GetFileVersionInfo(moduleFileName, NULL, versionInfoSize, &data[0])) {
-        return std::nullopt;
-    }
+	// GetFileVersionInfo
+	if (!GetFileVersionInfo(moduleFileName, NULL, versionInfoSize, &data[0])) {
+		return std::nullopt;
+	}
 
-    UINT randomPointer = 0;
-    VS_FIXEDFILEINFO* fixedFileInfo = nullptr;
-    if (!VerQueryValue(&data[0], TEXT("\\"), (void**)&fixedFileInfo, &randomPointer)) {
-        return std::nullopt;
-    }
+	UINT randomPointer = 0;
+	VS_FIXEDFILEINFO* fixedFileInfo = nullptr;
+	if (!VerQueryValue(&data[0], TEXT("\\"), (void**)&fixedFileInfo, &randomPointer)) {
+		return std::nullopt;
+	}
 
-    return Version ({
-    	HIWORD(fixedFileInfo->dwProductVersionMS),
-    	LOWORD(fixedFileInfo->dwProductVersionMS),
-    	HIWORD(fixedFileInfo->dwProductVersionLS),
-    	LOWORD(fixedFileInfo->dwProductVersionLS)
-    });
+	return Version ({
+		HIWORD(fixedFileInfo->dwProductVersionMS),
+		LOWORD(fixedFileInfo->dwProductVersionMS),
+		HIWORD(fixedFileInfo->dwProductVersionLS),
+		LOWORD(fixedFileInfo->dwProductVersionLS)
+	});
 }
 
 std::string UpdateCheckerBase::GetVersionAsString(HMODULE dll) {
-    auto currentVersion = UpdateCheckerBase::GetCurrentVersion(dll);
-    std::stringstream version;
-    if (currentVersion) {
-        version << currentVersion->at(0) << "." << currentVersion->at(1) << "." << currentVersion->at(2) << "." << currentVersion->at(3);
-    }
-    else {
-        version << __DATE__;
-    }
-    return version.str();
+	auto currentVersion = UpdateCheckerBase::GetCurrentVersion(dll);
+	std::stringstream version;
+	if (currentVersion) {
+		version << currentVersion->at(0) << "." << currentVersion->at(1) << "." << currentVersion->at(2) << "." << currentVersion->at(3);
+	}
+	else {
+		version << __DATE__;
+	}
+	return version.str();
 }
 
 #ifndef ARCDPS_EXTENSION_NO_CPR
 #include <cpr/cpr.h>
 
 void UpdateCheckerBase::CheckForUpdate(HMODULE dll, std::string repo) {
-    auto currentVersion = GetCurrentVersion(dll);
-    if (!currentVersion) return;
-    version = currentVersion.value();
+	auto currentVersion = GetCurrentVersion(dll);
+	if (!currentVersion) return;
+	version = currentVersion.value();
 
-    std::thread cprCall([this, repo]() {
-        std::string link = "https://api.github.com/repos/";
-        link.append(repo);
-    	link.append("/releases/latest");
+	std::thread cprCall([this, repo]() {
+		std::string link = "https://api.github.com/repos/";
+		link.append(repo);
+		link.append("/releases/latest");
 
-        cpr::Response response = cpr::Get(cpr::Url{ link });
+		cpr::Response response = cpr::Get(cpr::Url{ link });
 
-        if (response.status_code == 200) {
-            auto json = nlohmann::json::parse(response.text);
+		if (response.status_code == 200) {
+			auto json = nlohmann::json::parse(response.text);
 
-            std::string tagName = json.at("tag_name").get<std::string>();
-            if (tagName[0] == 'v') {
-                tagName.erase(0, 1);
-            }
+			std::string tagName = json.at("tag_name").get<std::string>();
+			if (tagName[0] == 'v') {
+				tagName.erase(0, 1);
+			}
 
-            std::vector<std::string> versionNums;
-            std::istringstream iss(tagName);
+			std::vector<std::string> versionNums;
+			std::istringstream iss(tagName);
 
-            for (std::string token; std::getline(iss, token, '.'); )
-            {
-                versionNums.push_back(std::move(token));
-            }
+			for (std::string token; std::getline(iss, token, '.'); )
+			{
+				versionNums.push_back(std::move(token));
+			}
 
-            // TODO: use semver to calculate this. So all semver releases can be parsed and not only my hardcoded ones :)
-        	// libary for it: https://github.com/Neargye/semver
-        	
-            if (versionNums.size() < 3) return;
+			// TODO: use semver to calculate this. So all semver releases can be parsed and not only my hardcoded ones :)
+			// libary for it: https://github.com/Neargye/semver
+			
+			if (versionNums.size() < 3) return;
 
-            newVersion[0] = std::stof(versionNums[0]);
-            newVersion[1] = std::stof(versionNums[1]);
-            newVersion[2] = std::stof(versionNums[2]);
+			newVersion[0] = std::stof(versionNums[0]);
+			newVersion[1] = std::stof(versionNums[1]);
+			newVersion[2] = std::stof(versionNums[2]);
 
-            if (newVersion[0] > version[0] || newVersion[1] > version[1] || newVersion[2] > version[2]) {
-                Status expected = Status::Unknown;
-                update_status.compare_exchange_strong(expected, Status::UpdateAvailable);
-            }
+			if (newVersion[0] > version[0] || newVersion[1] > version[1] || newVersion[2] > version[2]) {
+				Status expected = Status::Unknown;
+				update_status.compare_exchange_strong(expected, Status::UpdateAvailable);
+			}
 
-        	// load download URL
-            downloadUrl = json["assets"][0]["browser_download_url"].get<std::string>();
-        }
-    });
+			// load download URL
+			downloadUrl = json["assets"][0]["browser_download_url"].get<std::string>();
+		}
+	});
 
-    cprCall.detach();
+	cprCall.detach();
 }
 
 void UpdateCheckerBase::UpdateAutomatically(HMODULE dll) {
-    if (downloadUrl.empty()) return;
+	if (downloadUrl.empty()) return;
 
-    Status expected = Status::UpdateAvailable;
-    if (!update_status.compare_exchange_strong(expected, Status::UpdatingInProgress))
-        return;
+	Status expected = Status::UpdateAvailable;
+	if (!update_status.compare_exchange_strong(expected, Status::UpdatingInProgress))
+		return;
 
-    std::thread t([this, dll]() {
-        cpr::Session session;
-        session.SetUrl(cpr::Url{ downloadUrl });
+	std::thread t([this, dll]() {
+		cpr::Session session;
+		session.SetUrl(cpr::Url{ downloadUrl });
 
-        CHAR dllPath[MAX_PATH] = { 0 };
-        if (GetModuleFileNameA(dll, dllPath, _countof(dllPath)) == 0) {
-            update_status = Status::UpdateError;
-            return;
-        }
+		CHAR dllPath[MAX_PATH] = { 0 };
+		if (GetModuleFileNameA(dll, dllPath, _countof(dllPath)) == 0) {
+			update_status = Status::UpdateError;
+			return;
+		}
 
-        std::string dllPathTemp(dllPath);
-        dllPathTemp.append(".tmp");
+		std::string dllPathTemp(dllPath);
+		dllPathTemp.append(".tmp");
 
-    	// new context to have ofstream and session only temporary (they have to be closed later on)
-        {
-            std::ofstream outFile(dllPathTemp, std::ios::binary);
+		// new context to have ofstream and session only temporary (they have to be closed later on)
+		{
+			std::ofstream outFile(dllPathTemp, std::ios::binary);
 
-            cpr::Response response = session.Download(outFile);
-            if (response.status_code != 200) {
-                // Error downloading
-                update_status = Status::UpdateError;
-                return;
-            }
-        }
+			cpr::Response response = session.Download(outFile);
+			if (response.status_code != 200) {
+				// Error downloading
+				update_status = Status::UpdateError;
+				return;
+			}
+		}
 
-        std::string dllPathOld(dllPath);
-        dllPathOld.append(".old");
-    	
-        if (std::rename(dllPath, dllPathOld.c_str())) {
-	        // Error renaming
-            update_status = Status::UpdateError;
-            return;
-        }
+		std::string dllPathOld(dllPath);
+		dllPathOld.append(".old");
+		
+		if (std::rename(dllPath, dllPathOld.c_str())) {
+			// Error renaming
+			update_status = Status::UpdateError;
+			return;
+		}
 
-    	if (std::rename(dllPathTemp.c_str(), dllPath)) {
-    		// Error renaming
-            update_status = Status::UpdateError;
-            return;
-    	}
+		if (std::rename(dllPathTemp.c_str(), dllPath)) {
+			// Error renaming
+			update_status = Status::UpdateError;
+			return;
+		}
 
-        update_status = Status::RestartPending;
-    });
+		update_status = Status::RestartPending;
+	});
 
-    t.detach();
+	t.detach();
 }
 
 #endif

--- a/UpdateCheckerBase.cpp
+++ b/UpdateCheckerBase.cpp
@@ -218,11 +218,6 @@ UpdateCheckerBase::Version UpdateCheckerBase::ParseVersion(std::string_view vers
 	// libary for it: https://github.com/Neargye/semver
 
 	Version result{};
-
-	if (versionString[0] == 'v') {
-		versionString = versionString.substr(1);
-	}
-
 	size_t tokenIndex = 0;
 	size_t start = 0;
 	do

--- a/UpdateCheckerBase.h
+++ b/UpdateCheckerBase.h
@@ -20,10 +20,18 @@ public:
 	
 	/**
 	 * \brief Check if a new update is available on the given github repo. Call this inside `mod_init()`.
-	 * \param dll the module to this dll (self_dll) got from DllMain()
+	 * \param currentVersion the current version of the binary for which updates should be compared against
 	 * \param repo string to the repo (e.g. `knoxfighter/arcdps-killproof.me-plugin`)
+	 * \param allowPrerelease true if pre-releases should also be considered for updating
 	 */
-	void CheckForUpdate(HMODULE dll, std::string repo);
+	void CheckForUpdate(Version currentVersion, std::string repo, bool allowPrerelease);
+
+	/**
+	 * \brief Executes a http get request (provided for mocking support in testing)
+	 * \param url the url to get
+	 * \return a string representing the content of the response, or std::nullopt if an error occured
+	 */
+	virtual std::optional<std::string> HttpGet(const std::string& url);
 
 	/**
 	 * \brief Draw command for running in `mod_imgui()`
@@ -55,6 +63,21 @@ public:
 	 * \param dll the module to this dll (self_dll) got from DllMain()
 	 */
 	void UpdateAutomatically(HMODULE dll);
+
+	/**
+	 * \brief Check if a new update is available on the given github repo. Call this inside `mod_init()`.
+	 * \param repoVersion Version in repo
+	 * \param currentVersion Version in current binary
+	 * \return true if the repo version is newer than the current one
+	 */
+	virtual bool IsNewer(const Version& repoVersion, const Version& currentVersion);
+
+	/**
+	 * \brief Parse a version object from a version string
+	 * \param versionString the version string
+	 * \return version as a version object
+	 */
+	virtual Version ParseVersion(std::string_view versionString);
 
 protected:
 	std::atomic<Status> update_status = Status::Unknown;

--- a/UpdateCheckerTest.cpp
+++ b/UpdateCheckerTest.cpp
@@ -1,0 +1,369 @@
+#pragma warning(push, 0)
+#include <gtest/gtest.h>
+#pragma warning(pop)
+
+#include <UpdateCheckerBase.h>
+#include <queue>
+
+constexpr char MOCK_RESPONSE_ALL_RELEASES[] = R"DELIMITER([
+  {
+    "url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45627408",
+    "assets_url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45627408/assets",
+    "upload_url": "https://uploads.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45627408/assets{?name,label}",
+    "html_url": "https://github.com/knoxfighter/arcdps-killproof.me-plugin/releases/tag/v2.5.2",
+    "id": 45627408,
+    "author": {
+      "login": "knoxfighter",
+      "id": 18680546,
+      "node_id": "MDQ6VXNlcjE4NjgwNTQ2",
+      "avatar_url": "https://avatars.githubusercontent.com/u/18680546?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/knoxfighter",
+      "html_url": "https://github.com/knoxfighter",
+      "followers_url": "https://api.github.com/users/knoxfighter/followers",
+      "following_url": "https://api.github.com/users/knoxfighter/following{/other_user}",
+      "gists_url": "https://api.github.com/users/knoxfighter/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/knoxfighter/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/knoxfighter/subscriptions",
+      "organizations_url": "https://api.github.com/users/knoxfighter/orgs",
+      "repos_url": "https://api.github.com/users/knoxfighter/repos",
+      "events_url": "https://api.github.com/users/knoxfighter/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/knoxfighter/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "node_id": "MDc6UmVsZWFzZTQ1NjI3NDA4",
+    "tag_name": "v2.5.2",
+    "target_commitish": "master",
+    "name": "v2.5.2",
+    "draft": false,
+    "prerelease": false,
+    "created_at": "2021-07-02T14:23:47Z",
+    "published_at": "2021-07-02T14:29:54Z",
+    "assets": [
+      {
+        "url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/assets/39626428",
+        "id": 39626428,
+        "node_id": "MDEyOlJlbGVhc2VBc3NldDM5NjI2NDI4",
+        "name": "d3d9_arcdps_killproof_me.dll",
+        "label": null,
+        "uploader": {
+          "login": "knoxfighter",
+          "id": 18680546,
+          "node_id": "MDQ6VXNlcjE4NjgwNTQ2",
+          "avatar_url": "https://avatars.githubusercontent.com/u/18680546?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/knoxfighter",
+          "html_url": "https://github.com/knoxfighter",
+          "followers_url": "https://api.github.com/users/knoxfighter/followers",
+          "following_url": "https://api.github.com/users/knoxfighter/following{/other_user}",
+          "gists_url": "https://api.github.com/users/knoxfighter/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/knoxfighter/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/knoxfighter/subscriptions",
+          "organizations_url": "https://api.github.com/users/knoxfighter/orgs",
+          "repos_url": "https://api.github.com/users/knoxfighter/repos",
+          "events_url": "https://api.github.com/users/knoxfighter/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/knoxfighter/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "content_type": "application/x-msdownload",
+        "state": "uploaded",
+        "size": 1437184,
+        "download_count": 10343,
+        "created_at": "2021-07-02T14:27:36Z",
+        "updated_at": "2021-07-02T14:27:40Z",
+        "browser_download_url": "https://github.com/knoxfighter/arcdps-killproof.me-plugin/releases/download/v2.5.2/d3d9_arcdps_killproof_me.dll"
+      }
+    ],
+    "tarball_url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/tarball/v2.5.2",
+    "zipball_url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/zipball/v2.5.2",
+    "body": "**Make sure you have the newest C++ 2015-2019 redistributable installed:\r\n[Microsoft download page](https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0)**\r\n**[Direct download Link](https://aka.ms/vs/16/release/vc_redist.x64.exe)**\r\n\r\n- fixed coffers counted twice for LI/LD",
+    "reactions": {
+      "url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45627408/reactions",
+      "total_count": 1,
+      "+1": 0,
+      "-1": 0,
+      "laugh": 0,
+      "hooray": 0,
+      "confused": 0,
+      "heart": 0,
+      "rocket": 1,
+      "eyes": 0
+    }
+  },
+  {
+    "url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45369082",
+    "assets_url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45369082/assets",
+    "upload_url": "https://uploads.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45369082/assets{?name,label}",
+    "html_url": "https://github.com/knoxfighter/arcdps-killproof.me-plugin/releases/tag/v2.5.1",
+    "id": 45369082,
+    "author": {
+      "login": "knoxfighter",
+      "id": 18680546,
+      "node_id": "MDQ6VXNlcjE4NjgwNTQ2",
+      "avatar_url": "https://avatars.githubusercontent.com/u/18680546?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/knoxfighter",
+      "html_url": "https://github.com/knoxfighter",
+      "followers_url": "https://api.github.com/users/knoxfighter/followers",
+      "following_url": "https://api.github.com/users/knoxfighter/following{/other_user}",
+      "gists_url": "https://api.github.com/users/knoxfighter/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/knoxfighter/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/knoxfighter/subscriptions",
+      "organizations_url": "https://api.github.com/users/knoxfighter/orgs",
+      "repos_url": "https://api.github.com/users/knoxfighter/repos",
+      "events_url": "https://api.github.com/users/knoxfighter/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/knoxfighter/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "node_id": "MDc6UmVsZWFzZTQ1MzY5MDgy",
+    "tag_name": "v2.5.1",
+    "target_commitish": "master",
+    "name": "v2.5.1",
+    "draft": false,
+    "prerelease": false,
+    "created_at": "2021-06-28T16:18:31Z",
+    "published_at": "2021-06-28T16:20:37Z",
+    "assets": [
+      {
+        "url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/assets/39365466",
+        "id": 39365466,
+        "node_id": "MDEyOlJlbGVhc2VBc3NldDM5MzY1NDY2",
+        "name": "d3d9_arcdps_killproof_me.dll",
+        "label": null,
+        "uploader": {
+          "login": "knoxfighter",
+          "id": 18680546,
+          "node_id": "MDQ6VXNlcjE4NjgwNTQ2",
+          "avatar_url": "https://avatars.githubusercontent.com/u/18680546?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/knoxfighter",
+          "html_url": "https://github.com/knoxfighter",
+          "followers_url": "https://api.github.com/users/knoxfighter/followers",
+          "following_url": "https://api.github.com/users/knoxfighter/following{/other_user}",
+          "gists_url": "https://api.github.com/users/knoxfighter/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/knoxfighter/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/knoxfighter/subscriptions",
+          "organizations_url": "https://api.github.com/users/knoxfighter/orgs",
+          "repos_url": "https://api.github.com/users/knoxfighter/repos",
+          "events_url": "https://api.github.com/users/knoxfighter/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/knoxfighter/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "content_type": "application/x-msdownload",
+        "state": "uploaded",
+        "size": 1437184,
+        "download_count": 1919,
+        "created_at": "2021-06-28T16:20:14Z",
+        "updated_at": "2021-06-28T16:20:18Z",
+        "browser_download_url": "https://github.com/knoxfighter/arcdps-killproof.me-plugin/releases/download/v2.5.1/d3d9_arcdps_killproof_me.dll"
+      }
+    ],
+    "tarball_url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/tarball/v2.5.1",
+    "zipball_url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/zipball/v2.5.1",
+    "body": "**Make sure you have the newest C++ 2015-2019 redistributable installed:\r\n[Microsoft download page](https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0)**\r\n**[Direct download Link](https://aka.ms/vs/16/release/vc_redist.x64.exe)**\r\n\r\n- fixed broken automatic update download\r\n- sorting respects coffers\r\n- fixed players shown twice after adding them twice\r\n- fixed clear button not clearing already tracked and manually readded players"
+  }
+])DELIMITER";
+
+constexpr char MOCK_RESPONSE_LATEST_RELEASE[] = R"DELIMITER({
+  "url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45627408",
+  "assets_url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45627408/assets",
+  "upload_url": "https://uploads.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45627408/assets{?name,label}",
+  "html_url": "https://github.com/knoxfighter/arcdps-killproof.me-plugin/releases/tag/v2.5.2",
+  "id": 45627408,
+  "author": {
+    "login": "knoxfighter",
+    "id": 18680546,
+    "node_id": "MDQ6VXNlcjE4NjgwNTQ2",
+    "avatar_url": "https://avatars.githubusercontent.com/u/18680546?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/knoxfighter",
+    "html_url": "https://github.com/knoxfighter",
+    "followers_url": "https://api.github.com/users/knoxfighter/followers",
+    "following_url": "https://api.github.com/users/knoxfighter/following{/other_user}",
+    "gists_url": "https://api.github.com/users/knoxfighter/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/knoxfighter/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/knoxfighter/subscriptions",
+    "organizations_url": "https://api.github.com/users/knoxfighter/orgs",
+    "repos_url": "https://api.github.com/users/knoxfighter/repos",
+    "events_url": "https://api.github.com/users/knoxfighter/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/knoxfighter/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "node_id": "MDc6UmVsZWFzZTQ1NjI3NDA4",
+  "tag_name": "v2.5.2",
+  "target_commitish": "master",
+  "name": "v2.5.2",
+  "draft": false,
+  "prerelease": false,
+  "created_at": "2021-07-02T14:23:47Z",
+  "published_at": "2021-07-02T14:29:54Z",
+  "assets": [
+    {
+      "url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/assets/39626428",
+      "id": 39626428,
+      "node_id": "MDEyOlJlbGVhc2VBc3NldDM5NjI2NDI4",
+      "name": "d3d9_arcdps_killproof_me.dll",
+      "label": null,
+      "uploader": {
+        "login": "knoxfighter",
+        "id": 18680546,
+        "node_id": "MDQ6VXNlcjE4NjgwNTQ2",
+        "avatar_url": "https://avatars.githubusercontent.com/u/18680546?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/knoxfighter",
+        "html_url": "https://github.com/knoxfighter",
+        "followers_url": "https://api.github.com/users/knoxfighter/followers",
+        "following_url": "https://api.github.com/users/knoxfighter/following{/other_user}",
+        "gists_url": "https://api.github.com/users/knoxfighter/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/knoxfighter/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/knoxfighter/subscriptions",
+        "organizations_url": "https://api.github.com/users/knoxfighter/orgs",
+        "repos_url": "https://api.github.com/users/knoxfighter/repos",
+        "events_url": "https://api.github.com/users/knoxfighter/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/knoxfighter/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "content_type": "application/x-msdownload",
+      "state": "uploaded",
+      "size": 1437184,
+      "download_count": 10344,
+      "created_at": "2021-07-02T14:27:36Z",
+      "updated_at": "2021-07-02T14:27:40Z",
+      "browser_download_url": "https://github.com/knoxfighter/arcdps-killproof.me-plugin/releases/download/v2.5.2/d3d9_arcdps_killproof_me.dll"
+    }
+  ],
+  "tarball_url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/tarball/v2.5.2",
+  "zipball_url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/zipball/v2.5.2",
+  "body": "**Make sure you have the newest C++ 2015-2019 redistributable installed:\r\n[Microsoft download page](https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0)**\r\n**[Direct download Link](https://aka.ms/vs/16/release/vc_redist.x64.exe)**\r\n\r\n- fixed coffers counted twice for LI/LD",
+  "reactions": {
+    "url": "https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/45627408/reactions",
+    "total_count": 1,
+    "+1": 0,
+    "-1": 0,
+    "laugh": 0,
+    "hooray": 0,
+    "confused": 0,
+    "heart": 0,
+    "rocket": 1,
+    "eyes": 0
+  }
+}
+)DELIMITER";
+
+class UpdateCheckerMock : public UpdateCheckerBase
+{
+public:
+	void Draw() override
+	{
+	}
+
+	Status GetStatus() const
+	{
+		return update_status.load();
+	}
+
+	Version GetNewVersion() const
+	{
+		return newVersion;
+	}
+
+	std::string GetDownloadUrl() const
+	{
+		return downloadUrl;
+	}
+
+    std::queue<std::string> QueuedResponses;
+    std::optional<std::string> HttpGet(const std::string&) override
+	{
+		assert(QueuedResponses.size() > 0);
+
+        std::optional<std::string> result = QueuedResponses.front();
+        QueuedResponses.pop();
+        return result;
+	}
+};
+
+TEST(UpdateCheckerTest, ParseVersion)
+{
+	UpdateCheckerMock updater;
+	// "Good path"
+	EXPECT_EQ(updater.ParseVersion("1.2.3"), UpdateCheckerBase::Version({1, 2, 3, 0}));
+	EXPECT_EQ(updater.ParseVersion("v1.2.3"), UpdateCheckerBase::Version({1, 2, 3, 0}));
+	EXPECT_EQ(updater.ParseVersion("1v.2.3"), UpdateCheckerBase::Version({1, 2, 3, 0}));
+	EXPECT_EQ(updater.ParseVersion("rc1v.r2c.hh3_"), UpdateCheckerBase::Version({1, 2, 3, 0}));
+
+	// Tokens after the third one should be ignored
+	EXPECT_EQ(updater.ParseVersion("v1.2.rc3.4"), UpdateCheckerBase::Version({1, 2, 3, 0}));
+	EXPECT_EQ(updater.ParseVersion("v1.2.rc3.4.5.6"), UpdateCheckerBase::Version({1, 2, 3, 0}));
+
+	// tokens that contain no digits should be ignored
+	EXPECT_EQ(updater.ParseVersion("5.4.a.3.4"), UpdateCheckerBase::Version({5, 4, 3, 0}));
+
+	// Invalid strings should return all zero version
+	EXPECT_EQ(updater.ParseVersion("1.2"), UpdateCheckerBase::Version({0, 0, 0, 0}));
+	EXPECT_EQ(updater.ParseVersion("v"), UpdateCheckerBase::Version({0, 0, 0, 0}));
+	EXPECT_EQ(updater.ParseVersion(".."), UpdateCheckerBase::Version({0, 0, 0, 0}));
+	EXPECT_EQ(updater.ParseVersion("..1"), UpdateCheckerBase::Version({0, 0, 0, 0}));
+	EXPECT_EQ(updater.ParseVersion("a.b"), UpdateCheckerBase::Version({0, 0, 0, 0}));
+}
+
+TEST(UpdateCheckerTest, IsNewer)
+{
+	UpdateCheckerMock updater;
+	// Last version token is ignored
+	EXPECT_FALSE(updater.IsNewer(UpdateCheckerBase::Version({1, 2, 3, 0}), UpdateCheckerBase::Version({1, 2, 3, 0})));
+	EXPECT_FALSE(updater.IsNewer(UpdateCheckerBase::Version({1, 2, 3, 0}), UpdateCheckerBase::Version({1, 2, 3, 200})));
+	EXPECT_FALSE(updater.IsNewer(UpdateCheckerBase::Version({1, 2, 3, 200}), UpdateCheckerBase::Version({1, 2, 3, 0})));
+
+	// Newer version can be detected
+	EXPECT_TRUE(updater.IsNewer(UpdateCheckerBase::Version({1, 2, 4, 0}), UpdateCheckerBase::Version({1, 2, 3, 0})));
+	EXPECT_FALSE(updater.IsNewer(UpdateCheckerBase::Version({1, 2, 3, 0}), UpdateCheckerBase::Version({1, 2, 4, 0})));
+
+	// Numbers earlier in the version number take precedence
+	EXPECT_TRUE(updater.IsNewer(UpdateCheckerBase::Version({1, 3, 1, 0}), UpdateCheckerBase::Version({1, 2, 4, 0})));
+	EXPECT_FALSE(updater.IsNewer(UpdateCheckerBase::Version({1, 2, 4, 0}), UpdateCheckerBase::Version({1, 3, 1, 0})));
+	EXPECT_TRUE(updater.IsNewer(UpdateCheckerBase::Version({10, 0, 0, 0}), UpdateCheckerBase::Version({9, 9, 9, 9})));
+	EXPECT_FALSE(updater.IsNewer(UpdateCheckerBase::Version({9, 9, 9, 9}), UpdateCheckerBase::Version({10, 0, 0, 0})));
+}
+
+TEST(UpdateCheckerTest, CheckForUpdate_Stable)
+{
+	UpdateCheckerMock updater;
+    updater.QueuedResponses.push(MOCK_RESPONSE_LATEST_RELEASE);
+	updater.CheckForUpdate(UpdateCheckerBase::Version({2, 5, 1, 0}), "knoxfighter/arcdps-killproof.me-plugin", false);
+    Sleep(1000); // Wait for spawned thread to exit
+    EXPECT_EQ(updater.GetStatus(), UpdateCheckerBase::Status::UpdateAvailable);
+	EXPECT_EQ(updater.GetNewVersion(), UpdateCheckerBase::Version({2, 5, 2, 0}));
+	EXPECT_EQ(updater.GetDownloadUrl(), "https://github.com/knoxfighter/arcdps-killproof.me-plugin/releases/download/v2.5.2/d3d9_arcdps_killproof_me.dll");
+}
+
+// Same as above except the currentVersion is newer and thus an update is not available
+TEST(UpdateCheckerTest, CheckForUpdate_Stable_Negative)
+{
+	UpdateCheckerMock updater;
+    updater.QueuedResponses.push(MOCK_RESPONSE_LATEST_RELEASE);
+	updater.CheckForUpdate(UpdateCheckerBase::Version({3, 0, 0, 0}), "knoxfighter/arcdps-killproof.me-plugin", false);
+    Sleep(1000); // Wait for spawned thread to exit
+    EXPECT_EQ(updater.GetStatus(), UpdateCheckerBase::Status::Unknown);
+
+    // These are still filled out, and the status is what indicates that there is no available release
+	EXPECT_EQ(updater.GetNewVersion(), UpdateCheckerBase::Version({2, 5, 2, 0}));
+	EXPECT_EQ(updater.GetDownloadUrl(), "https://github.com/knoxfighter/arcdps-killproof.me-plugin/releases/download/v2.5.2/d3d9_arcdps_killproof_me.dll");
+}
+
+TEST(UpdateCheckerTest, CheckForUpdate_Prerelease)
+{
+	UpdateCheckerMock updater;
+    updater.QueuedResponses.push(MOCK_RESPONSE_ALL_RELEASES);
+	updater.CheckForUpdate(UpdateCheckerBase::Version({2, 5, 1, 0}), "knoxfighter/arcdps-killproof.me-plugin", true);
+    Sleep(1000); // Wait for spawned thread to exit
+    EXPECT_EQ(updater.GetStatus(), UpdateCheckerBase::Status::UpdateAvailable);
+	EXPECT_EQ(updater.GetNewVersion(), UpdateCheckerBase::Version({2, 5, 2, 0}));
+	EXPECT_EQ(updater.GetDownloadUrl(), "https://github.com/knoxfighter/arcdps-killproof.me-plugin/releases/download/v2.5.2/d3d9_arcdps_killproof_me.dll");
+}


### PR DESCRIPTION
- Fixed indentation in UpdateCheckerBase
- Added support for more version formats (ignore all characters at start and end of version, and provide version parsing as a virtual function for addons to potentially overload further)
- Added version comparison as a virtual function for addons to potentially overload in case one wants to, for example, use fewer/more version tokens
- Harden version parsing (fixing issues when version token is empty or only contains letters or similar)
- Added some commented out loglines; they are all fmt format right now, need to figure out if that is what we want to do (and then provide it as a virtual function or similar)
- Added support for pre-releases
- Hardened download link detection (use first asset with a .dll ending instead)

Testing: Added unit tests for the changed functions :)