### PR TITLE
WindowReposition improvements

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -29,7 +29,7 @@ void MainWindow::Draw(const Param& param) {
 	/**
 	 * Reposition Window
 	 */
-	ImGuiEx::WindowReposition(param.position, param.cornerVector, param.cornerPosition, param.fromWindowID,
+	ImGuiEx::WindowReposition(nullptr, param.position, param.cornerVector, param.cornerPosition, param.fromWindowID,
 							  param.anchorPanelCornerPosition, param.selfPanelCornerPosition);
 
 	ImGui::End();

--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -599,10 +599,16 @@ namespace ImGuiEx {
 			column.IsEnabledNextFrame = !column.IsEnabled;
 	}
 
-	void WindowReposition(Position position, const ImVec2& cornerVector, CornerPosition cornerPosition, ImGuiID fromWindowID,
+	bool WindowReposition(ImGuiWindow* window, Position position, const ImVec2& cornerVector, CornerPosition cornerPosition, ImGuiID fromWindowID,
 	                      CornerPosition anchorPanelCornerPosition, CornerPosition selfPanelCornerPosition) {
-		const ImVec2& windowSize = ImGui::GetWindowSize();
+		if (window == nullptr) {
+			window = ImGui::GetCurrentWindowRead();
+		}
+
+		const ImVec2& windowSize = window->Size;
 		const ImVec2& displaySize = ImGui::GetIO().DisplaySize;
+
+		const ImVec2 startPos = window->Pos;
 
 		switch (position) {
 			case Position::ScreenRelative: {
@@ -629,7 +635,7 @@ namespace ImGuiEx {
 					}
 				}
 
-				ImGui::SetWindowPos(setPosition);
+				ImGui::SetWindowPos(window, setPosition);
 				break;
 			}
 			case Position::WindowRelative: {
@@ -686,10 +692,13 @@ namespace ImGuiEx {
 				// clip to screen border
 				setPosition = ImMax(setPosition, ImVec2(0.f, 0.f));
 
-				ImGui::SetWindowPos(setPosition);
+				ImGui::SetWindowPos(window, setPosition);
 				break;
 			}
 		}
+
+		const ImVec2& endPos = window->Pos;
+		return startPos.x != endPos.x || startPos.y != endPos.y;
 	}
 
 #ifdef _WIN32

--- a/Widgets.h
+++ b/Widgets.h
@@ -17,7 +17,8 @@ namespace ImGuiEx {
 	void BeginMenu(const char* menu_label, std::function<void()> draw_func);
 	bool BeginPopupContextWindow(const char* str_id, ImGuiPopupFlags popup_flags, ImGuiHoveredFlags hovered_flags);
 	void MenuItemTableColumnVisibility(ImGuiTable* table, int columnIdx);
-	void WindowReposition(Position position, const ImVec2& cornerVector, CornerPosition cornerPosition, ImGuiID fromWindowID,
+	// returns true if the window moved
+	bool WindowReposition(ImGuiWindow* window, Position position, const ImVec2& cornerVector, CornerPosition cornerPosition, ImGuiID fromWindowID,
 	                      CornerPosition anchorPanelCornerPosition, CornerPosition selfPanelCornerPosition);
 
 	template <typename E, typename = typename std::enable_if<std::is_enum<E>::value, void>::type>


### PR DESCRIPTION
- Allow explicitly specifying window (thus allowing changing the position of a window outside of that windows immediate context)
- Return bool that represents if the window moved. This matters because if windows have relationships against each other, you want to reposition windows until none of them move (bar cyclic relationships)