### PR TITLE
include vector to fix compile errors on newer versions of VS

### DIFF
--- a/UpdateCheckerBase.h
+++ b/UpdateCheckerBase.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <vector>
 #include <Windows.h>
 
 // Expected usage is as follows:


### PR DESCRIPTION
The project does not currently build on VS 2022 17.3.1 and newer due to a missing include of `<vector>`.

Previously, `<vector>` was being transitively included via the `<mutex>` include, which included `<chrono>`, which finally includes `<vector>`.


However, from VS 2022 17.3.1 onwards, https://github.com/microsoft/STL/pull/2604 removes `<mutex>`'s include of `<chrono>` in favor of a smaller internal header which does not include `<vector>`.