### PR TITLE
Process events with id 0 in the same thread as other events in EventProcessor

### DIFF
--- a/EventSequencer.cpp
+++ b/EventSequencer.cpp
@@ -23,7 +23,7 @@ ArcdpsExtension::EventSequencer::EventSequencer(const CallbackSignature& pCallba
 	mThread = std::jthread([this](std::stop_token stoken) {
 		while (!stoken.stop_requested()) {
 			while (!stoken.stop_requested() && !mElements.empty()) {
-				Runner();
+				Runner(mNextId);
 			}
 
 			if (stoken.stop_requested()) return;

--- a/EventSequencer.cpp
+++ b/EventSequencer.cpp
@@ -5,19 +5,7 @@
 
 void ArcdpsExtension::EventSequencer::ProcessEvent(cbtevent* pEv, ag* pSrc, ag* pDst, const char* pSkillname, uint64_t pId, uint64_t pRevision) {
 	std::lock_guard guard(mElementsMutex);
-	if (pId == 0) {
-		// if no events are queued call id=0 events directly
-		if (mElements.empty()) {
-			mCallback(pEv, pSrc, pDst, pSkillname, pId, pRevision);
-			return;
-		}
-
-		// insert it in the prio queue
-		mElements.emplace(pEv, pSrc, pDst, pSkillname, mLastId, pRevision);
-	} else {
-		mLastId = pId;
-		mElements.emplace(pEv, pSrc, pDst, pSkillname, pId, pRevision);
-	}
+	mElements.emplace(pEv, pSrc, pDst, pSkillname, pId, pRevision);
 }
 
 bool ArcdpsExtension::EventSequencer::EventsPending() const {
@@ -28,7 +16,6 @@ void ArcdpsExtension::EventSequencer::Reset() {
 	std::unique_lock guard(mElementsMutex);
 	mElements.clear();
 	mNextId = 2;
-	mLastId = 2;
 }
 
 ArcdpsExtension::EventSequencer::EventSequencer(const CallbackSignature& pCallback) : mCallback(pCallback) {

--- a/EventSequencer.h
+++ b/EventSequencer.h
@@ -87,14 +87,13 @@ namespace ArcdpsExtension {
 		std::mutex mElementsMutex;
 		std::jthread mThread;
 		uint64_t mNextId = 2; // Events start with ID 2 for some reason (it is always like that and no plans to change)
-		uint64_t mLastId = 2;
 		bool mThreadRunning = false;
 
 		template<bool First = true>
 		void Runner() {
 			std::unique_lock guard(mElementsMutex);
 
-			if (!mElements.empty() && mElements.begin()->Id == mNextId) {
+			if (!mElements.empty() && (!mElements.begin()->Id || mElements.begin()->Id == mNextId)) {
 				mThreadRunning = true;
 				auto item = mElements.extract(mElements.begin());
 				guard.unlock();
@@ -102,7 +101,7 @@ namespace ArcdpsExtension {
 				mThreadRunning = false;
 				Runner<false>();
 
-				if constexpr (First) {
+				if (First && mElements.begin()->Id != 0) {
 					++mNextId;
 				}
 			}

--- a/EventSequencer.h
+++ b/EventSequencer.h
@@ -101,7 +101,7 @@ namespace ArcdpsExtension {
 				mThreadRunning = false;
 				Runner<false>();
 
-				if (First && mElements.begin()->Id != 0) {
+				if (First && item.value().Id != 0) {
 					++mNextId;
 				}
 			}


### PR DESCRIPTION
Process events with id 0 in the same thread as other events in EventProcessor.

Events with id 0 are added at the front of the mElements multiset and their processing doesn't increment mNextId.
If an event with id 0 is found, only elements of id 0 are processed in that loop.