### PR TITLE
Add missing header

### DIFF
--- a/Windows/MainTable.h
+++ b/Windows/MainTable.h
@@ -13,6 +13,7 @@
 #include "../Widgets.h"
 
 #include <algorithm>
+#include <atomic>
 #include <bitset>
 #include <functional>
 #include <map>


### PR DESCRIPTION
Add missing header for std::atomic_bool . This is needed when building with clang on linux.
```
/Windows/Demo/../MainTable.h:262:8: error: no type named 'atomic_bool' in namespace 'std'
  262 |                 std::atomic_bool mSortNeeded = false;
      |                 ~~~~~^
```