### PR TITLE
Upgrade ImGui to 1.92.7

### DIFF
--- a/ImGUI upgrade.md
+++ b/ImGUI upgrade.md
@@ -1,5 +1,6 @@
 ImGui upgrade steps:
-- Copy TreeNodeBehavior() from upstream ImGui and re-add the code related to icons. Add ImGui:: prefix to every ImGui method.
-- Copy TableHeader() from upstream ImGui and re-add the code related to show label and texture. Add ImGui:: prefix to every ImGui method.
-- Copy ProgressBar() from upstream ImGui into AlignedProgressBar() and re-add the code related to alignment. Add ImGui:: prefix to every ImGui method.
-- Copy BeginMenu() from upstream ImGui and re-add the code related to. Add ImGui:: prefix to every ImGui method.
+- Copy TreeNodeBehavior() from upstream ImGui and re-add the code related to icons.
+- Copy TableHeader() from upstream ImGui and re-add the code related to show label and texture.
+- Copy ProgressBar() from upstream ImGui into AlignedProgressBar() and re-add the code related to alignment.
+- Copy BeginMenu() from upstream ImGui and re-add the code related to.
+- Copy the bottom part of TableDrawContextMenu() from upstream ImGui to MenuItemTableColumnVisibility().

--- a/ImGUI upgrade.md
+++ b/ImGUI upgrade.md
@@ -2,3 +2,4 @@ ImGui upgrade steps:
 - Copy TreeNodeBehavior() from upstream ImGui and re-add the code related to icons. Add ImGui:: prefix to every ImGui method.
 - Copy TableHeader() from upstream ImGui and re-add the code related to show label and texture. Add ImGui:: prefix to every ImGui method.
 - Copy ProgressBar() from upstream ImGui into AlignedProgressBar() and re-add the code related to alignment. Add ImGui:: prefix to every ImGui method.
+- Copy BeginMenu() from upstream ImGui and re-add the code related to. Add ImGui:: prefix to every ImGui method.

--- a/ImGUI upgrade.md
+++ b/ImGUI upgrade.md
@@ -1,2 +1,3 @@
 ImGui upgrade steps:
-- Copy TreeNodeBehavior from upstream ImGUI and re-add the code related to icons. Add ImGui:: prefix to every ImGui method.
+- Copy TreeNodeBehavior() from upstream ImGui and re-add the code related to icons. Add ImGui:: prefix to every ImGui method.
+- Copy TableHeader() from upstream ImGui and re-add the code related to show label and texture. Add ImGui:: prefix to every ImGui method.

--- a/ImGUI upgrade.md
+++ b/ImGUI upgrade.md
@@ -1,3 +1,4 @@
 ImGui upgrade steps:
 - Copy TreeNodeBehavior() from upstream ImGui and re-add the code related to icons. Add ImGui:: prefix to every ImGui method.
 - Copy TableHeader() from upstream ImGui and re-add the code related to show label and texture. Add ImGui:: prefix to every ImGui method.
+- Copy ProgressBar() from upstream ImGui into AlignedProgressBar() and re-add the code related to alignment. Add ImGui:: prefix to every ImGui method.

--- a/ImGUI upgrade.md
+++ b/ImGUI upgrade.md
@@ -1,2 +1,2 @@
-ImGUI upgrade steps:
-- Copy TreeNodeBehavior from upstream ImGUI and re-add the code related to icons
+ImGui upgrade steps:
+- Copy TreeNodeBehavior from upstream ImGUI and re-add the code related to icons. Add ImGui:: prefix to every ImGui method.

--- a/ImGUI upgrade.md
+++ b/ImGUI upgrade.md
@@ -1,0 +1,2 @@
+ImGUI upgrade steps:
+- Copy TreeNodeBehavior from upstream ImGUI and re-add the code related to icons

--- a/ImGUI upgrade.md
+++ b/ImGUI upgrade.md
@@ -4,3 +4,4 @@ ImGui upgrade steps:
 - Copy ProgressBar() from upstream ImGui into AlignedProgressBar() and re-add the code related to alignment.
 - Copy BeginMenu() from upstream ImGui and re-add the code related to.
 - Copy the bottom part of TableDrawContextMenu() from upstream ImGui to MenuItemTableColumnVisibility().
+- Copy BeginTableEx() from upstream ImGui and re-add the code related to child flags.

--- a/ImGui_Math.h
+++ b/ImGui_Math.h
@@ -3,4 +3,3 @@
 #include <imgui/imgui.h>
 
 static inline ImVec2 operator+(const ImVec2& lhs, const float rhs) { return ImVec2(lhs.x + rhs, lhs.y + rhs); }
-static inline ImVec4 operator*(const ImVec4& lhs, const float rhs) { return ImVec4(lhs.x * rhs, lhs.y * rhs, lhs.z * rhs, lhs.w * rhs); }

--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -144,7 +144,7 @@ namespace ImGuiEx {
 			return;
 
 		ImGuiTable* table = g.CurrentTable;
-		IM_ASSERT(table != NULL && "Need to call TableHeader() after BeginTable()!");
+		IM_ASSERT_USER_ERROR_RET(table != NULL, "Call should only be done while in BeginTable() scope!");
 		IM_ASSERT(table->CurrentColumn != -1);
 		const int column_n = table->CurrentColumn;
 		ImGuiTableColumn* column = &table->Columns[column_n];
@@ -152,14 +152,14 @@ namespace ImGuiEx {
 		// Label
 		if (label == NULL)
 			label = "";
-		const char* label_end = ImGui::FindRenderedTextEnd(label);
-		ImVec2 label_size = ImGui::CalcTextSize(label, label_end, true);
+		const char* label_end = FindRenderedTextEnd(label);
+		ImVec2 label_size = CalcTextSize(label, label_end, true);
 		ImVec2 label_pos = window->DC.CursorPos;
 
 		// If we already got a row height, there's use that.
 		// FIXME-TABLE: Padding problem if the correct outer-padding CellBgRect strays off our ClipRect?
-		ImRect cell_r = ImGui::TableGetCellBgRect(table, column_n);
-		float label_height = table->RowMinHeight - table->CellPaddingY * 2.0f;
+		ImRect cell_r = TableGetCellBgRect(table, column_n);
+		float label_height = table->RowMinHeight - table->RowCellPaddingY * 2.0f;
 		if (show_label) {
 			label_height = ImMax(label_size.y, label_height);
 		} else {
@@ -169,96 +169,95 @@ namespace ImGuiEx {
 		// Calculate ideal size for sort order arrow
 		float w_arrow = 0.0f;
 		float w_sort_text = 0.0f;
+		bool sort_arrow = false;
 		char sort_order_suf[4] = "";
 		const float ARROW_SCALE = 0.65f;
 		if ((table->Flags & ImGuiTableFlags_Sortable) && !(column->Flags & ImGuiTableColumnFlags_NoSort)) {
-			w_arrow = ImFloor(g.FontSize * ARROW_SCALE + g.Style.FramePadding.x);
+			w_arrow = ImTrunc(g.FontSize * ARROW_SCALE + g.Style.FramePadding.x);
+			if (column->SortOrder != -1)
+				sort_arrow = true;
 			if (column->SortOrder > 0) {
-				ImFormatString(sort_order_suf, IM_ARRAYSIZE(sort_order_suf), "%d", column->SortOrder + 1);
-				w_sort_text = g.Style.ItemInnerSpacing.x + ImGui::CalcTextSize(sort_order_suf).x;
+				ImFormatString(sort_order_suf, IM_COUNTOF(sort_order_suf), "%d", column->SortOrder + 1);
+				w_sort_text = g.Style.ItemInnerSpacing.x + CalcTextSize(sort_order_suf).x;
 			}
 		}
 
-		// We feed our unclipped width to the column without writing on CursorMaxPos, so that column is still considering for merging.
+		// We feed our unclipped width to the column without writing on CursorMaxPos, so that column is still considered for merging.
 		float max_pos_x = label_pos.x + w_sort_text + w_arrow;
 		if (show_label) {
 			max_pos_x += label_size.x;
 		} else {
 			max_pos_x += image_size;
 		}
-		column->ContentMaxXHeadersUsed = ImMax(column->ContentMaxXHeadersUsed, column->WorkMaxX);
+		column->ContentMaxXHeadersUsed = ImMax(column->ContentMaxXHeadersUsed, sort_arrow ? cell_r.Max.x : ImMin(max_pos_x, cell_r.Max.x));
 		column->ContentMaxXHeadersIdeal = ImMax(column->ContentMaxXHeadersIdeal, max_pos_x);
 
 		// Keep header highlighted when context menu is open.
-		const bool selected = (table->IsContextPopupOpen && table->ContextPopupColumn == column_n && table->InstanceInteracted == table->InstanceCurrent);
 		ImGuiID id = window->GetID(label);
 		ImRect bb(cell_r.Min.x, cell_r.Min.y, cell_r.Max.x, ImMax(cell_r.Max.y, cell_r.Min.y + label_height + g.Style.CellPadding.y * 2.0f));
-		ImGui::ItemSize(ImVec2(0.0f, label_height)); // Don't declare unclipped width, it'll be fed ContentMaxPosHeadersIdeal
-		if (!ImGui::ItemAdd(bb, id))
+		ItemSize(ImVec2(0.0f, label_height)); // Don't declare unclipped width, it'll be fed ContentMaxPosHeadersIdeal
+		if (!ItemAdd(bb, id))
 			return;
 
 		//GetForegroundDrawList()->AddRect(cell_r.Min, cell_r.Max, IM_COL32(255, 0, 0, 255)); // [DEBUG]
 		//GetForegroundDrawList()->AddRect(bb.Min, bb.Max, IM_COL32(255, 0, 0, 255)); // [DEBUG]
 
-		// Using AllowItemOverlap mode because we cover the whole cell, and we want user to be able to submit subsequent items.
+		// Using AllowOverlap mode because we cover the whole cell, and we want user to be able to submit subsequent items.
+		const bool highlight = (table->HighlightColumnHeader == column_n);
 		bool hovered, held;
-		bool pressed = ImGui::ButtonBehavior(bb, id, &hovered, &held, ImGuiButtonFlags_AllowItemOverlap);
-		if (g.ActiveId != id)
-			ImGui::SetItemAllowOverlap();
-		if (held || hovered || selected) {
-			const ImU32 col = ImGui::GetColorU32(held ? ImGuiCol_HeaderActive : hovered ? ImGuiCol_HeaderHovered
-																						: ImGuiCol_Header);
+		bool pressed = ButtonBehavior(bb, id, &hovered, &held, ImGuiButtonFlags_AllowOverlap);
+		if (held || hovered || highlight) {
+			const ImU32 col = GetColorU32(held ? ImGuiCol_HeaderActive : hovered ? ImGuiCol_HeaderHovered
+																				 : ImGuiCol_Header);
 			//RenderFrame(bb.Min, bb.Max, col, false, 0.0f);
-			ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, col, table->CurrentColumn);
-			ImGui::RenderNavHighlight(bb, id, ImGuiNavHighlightFlags_TypeThin | ImGuiNavHighlightFlags_NoRounding);
+			TableSetBgColor(ImGuiTableBgTarget_CellBg, col, table->CurrentColumn);
 		} else {
 			// Submit single cell bg color in the case we didn't submit a full header row
 			if ((table->RowFlags & ImGuiTableRowFlags_Headers) == 0)
-				ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, ImGui::GetColorU32(ImGuiCol_TableHeaderBg), table->CurrentColumn);
+				TableSetBgColor(ImGuiTableBgTarget_CellBg, GetColorU32(ImGuiCol_TableHeaderBg), table->CurrentColumn);
 		}
+		RenderNavCursor(bb, id, ImGuiNavRenderCursorFlags_Compact | ImGuiNavRenderCursorFlags_NoRounding);
 		if (held)
 			table->HeldHeaderColumn = (ImGuiTableColumnIdx) column_n;
 		window->DC.CursorPos.y -= g.Style.ItemSpacing.y * 0.5f;
 
 		// Drag and drop to re-order columns.
 		// FIXME-TABLE: Scroll request while reordering a column and it lands out of the scrolling zone.
-		if (held && (table->Flags & ImGuiTableFlags_Reorderable) && ImGui::IsMouseDragging(0) && !g.DragDropActive) {
-			// While moving a column it will jump on the other side of the mouse, so we also test for MouseDelta.x
-			table->ReorderColumn = (ImGuiTableColumnIdx) column_n;
+		if (held && (table->Flags & ImGuiTableFlags_Reorderable) && IsMouseDragging(0) && !g.DragDropActive) {
+			// - While moving a column it will jump on the other side of the mouse, so we also test for MouseDelta.x
+			// - We need to handle reordering across hidden columns.
+			//   In the configuration below, moving C to the right of E will lead to:
+			//      ... C [D] E  --->  ... [D] E  C   (Column name/index)
+			//      ... 2  3  4        ...  2  3  4   (Display order)
+			// - The other constraints are enforced by TableQueueSetColumnDisplayOrder() which might early out.
 			table->InstanceInteracted = table->InstanceCurrent;
-
-			// We don't reorder: through the frozen<>unfrozen line, or through a column that is marked with ImGuiTableColumnFlags_NoReorder.
 			if (g.IO.MouseDelta.x < 0.0f && g.IO.MousePos.x < cell_r.Min.x)
 				if (ImGuiTableColumn* prev_column = (column->PrevEnabledColumn != -1) ? &table->Columns[column->PrevEnabledColumn] : NULL)
-					if (!((column->Flags | prev_column->Flags) & ImGuiTableColumnFlags_NoReorder))
-						if ((column->IndexWithinEnabledSet < table->FreezeColumnsRequest) == (prev_column->IndexWithinEnabledSet < table->FreezeColumnsRequest))
-							table->ReorderColumnDir = -1;
+					TableQueueSetColumnDisplayOrder(table, column_n, prev_column->DisplayOrder);
 			if (g.IO.MouseDelta.x > 0.0f && g.IO.MousePos.x > cell_r.Max.x)
 				if (ImGuiTableColumn* next_column = (column->NextEnabledColumn != -1) ? &table->Columns[column->NextEnabledColumn] : NULL)
-					if (!((column->Flags | next_column->Flags) & ImGuiTableColumnFlags_NoReorder))
-						if ((column->IndexWithinEnabledSet < table->FreezeColumnsRequest) == (next_column->IndexWithinEnabledSet < table->FreezeColumnsRequest))
-							table->ReorderColumnDir = +1;
+					TableQueueSetColumnDisplayOrder(table, column_n, next_column->DisplayOrder);
 		}
 
 		// Sort order arrow
-		const float ellipsis_max = cell_r.Max.x - w_arrow - w_sort_text;
+		const float ellipsis_max = ImMax(cell_r.Max.x - w_arrow - w_sort_text, label_pos.x);
 		if ((table->Flags & ImGuiTableFlags_Sortable) && !(column->Flags & ImGuiTableColumnFlags_NoSort)) {
 			if (column->SortOrder != -1) {
 				float x = ImMax(cell_r.Min.x, cell_r.Max.x - w_arrow - w_sort_text);
 				float y = label_pos.y;
 				if (column->SortOrder > 0) {
-					ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetColorU32(ImGuiCol_Text, 0.70f));
-					ImGui::RenderText(ImVec2(x + g.Style.ItemInnerSpacing.x, y), sort_order_suf);
-					ImGui::PopStyleColor();
+					PushStyleColor(ImGuiCol_Text, GetColorU32(ImGuiCol_Text, 0.70f));
+					RenderText(ImVec2(x + g.Style.ItemInnerSpacing.x, y), sort_order_suf);
+					PopStyleColor();
 					x += w_sort_text;
 				}
-				ImGui::RenderArrow(window->DrawList, ImVec2(x, y), ImGui::GetColorU32(ImGuiCol_Text), column->SortDirection == ImGuiSortDirection_Ascending ? ImGuiDir_Up : ImGuiDir_Down, ARROW_SCALE);
+				RenderArrow(window->DrawList, ImVec2(x, y), GetColorU32(ImGuiCol_Text), column->SortDirection == ImGuiSortDirection_Ascending ? ImGuiDir_Up : ImGuiDir_Down, ARROW_SCALE);
 			}
 
 			// Handle clicking on column header to adjust Sort Order
 			if (pressed && table->ReorderColumn != column_n) {
-				ImGuiSortDirection sort_direction = ImGui::TableGetColumnNextSortDirection(column);
-				ImGui::TableSetColumnSortDirection(column_n, sort_direction, g.IO.KeyShift);
+				ImGuiSortDirection sort_direction = TableGetColumnNextSortDirection(column);
+				TableSetColumnSortDirection(column_n, sort_direction, g.IO.KeyShift);
 			}
 		}
 
@@ -266,7 +265,7 @@ namespace ImGuiEx {
 		// be merged into a single draw call.
 		//window->DrawList->AddCircleFilled(ImVec2(ellipsis_max, label_pos.y), 40, IM_COL32_WHITE);
 		if (show_label) {
-			// ImGui::RenderTextEllipsis(window->DrawList, label_pos, ImVec2(ellipsis_max, label_pos.y + label_height + g.Style.FramePadding.y), ellipsis_max,
+			// RenderTextEllipsis(window->DrawList, label_pos, ImVec2(ellipsis_max, label_pos.y + label_height + g.Style.FramePadding.y), ellipsis_max,
 			// 	ellipsis_max, label, label_end, &label_size);
 
 			float newX = label_pos.x;
@@ -275,18 +274,18 @@ namespace ImGuiEx {
 				case Alignment::Center:
 					// newX = label_pos.x + ((ellipsis_max - label_pos.x) / 2) - (label_size.x / 2);
 					newX = label_pos.x + ((cell_r.Max.x - label_pos.x - table->CellPaddingX) / 2) - (label_size.x / 2);
-					// ImGui::SetCursorPosX(cursorPosX + (textSpace / 2 - contentSize.x / 2));
+					// SetCursorPosX(cursorPosX + (textSpace / 2 - contentSize.x / 2));
 					break;
 				case Alignment::Right:
 					newX = ellipsis_max - label_size.x;
-					// ImGui::SetCursorPosX(cursorPosX + textSpace - contentSize.x);
+					// SetCursorPosX(cursorPosX + textSpace - contentSize.x);
 					break;
 				// nothing to do
 				case Alignment::Left:
 				case Alignment::Unaligned: break;
 			}
 
-			ImGui::RenderTextEllipsis(window->DrawList, ImVec2(newX, label_pos.y), ImVec2(ellipsis_max, label_pos.y + label_height + g.Style.FramePadding.y), ellipsis_max, ellipsis_max, label, label_end, &label_size);
+			RenderTextEllipsis(window->DrawList, ImVec2(newX, label_pos.y), ImVec2(ellipsis_max, bb.Max.y), ellipsis_max, label, label_end, &label_size);
 		} else {
 			float newX = label_pos.x;
 
@@ -294,32 +293,32 @@ namespace ImGuiEx {
 				case Alignment::Center:
 					// newX = label_pos.x + ((ellipsis_max - label_pos.x) / 2) - (image_size / 2);
 					newX = label_pos.x + ((cell_r.Max.x - label_pos.x - table->CellPaddingX) / 2) - (image_size / 2);
-					// ImGui::SetCursorPosX(cursorPosX + (textSpace / 2 - contentSize.x / 2));
+					// SetCursorPosX(cursorPosX + (textSpace / 2 - contentSize.x / 2));
 					break;
 				case Alignment::Right:
 					newX = ellipsis_max - image_size;
-					// ImGui::SetCursorPosX(cursorPosX + textSpace - contentSize.x);
+					// SetCursorPosX(cursorPosX + textSpace - contentSize.x);
 					break;
 				// nothing to do
 				case Alignment::Left:
 				case Alignment::Unaligned: break;
 			}
 
-			ImRect ibb(ImVec2(newX, label_pos.y), ImVec2(newX, label_pos.y) + image_size);
+			ImRect ibb(ImVec2(newX, label_pos.y), ImVec2(newX + image_size, label_pos.y + image_size));
 
 			window->DrawList->AddImage(texture, ibb.Min, ibb.Max);
 		}
 
-		// const bool text_clipped = label_size.x > (ellipsis_max - label_pos.x);
-		// if (text_clipped && hovered && g.HoveredIdNotActiveTimer > g.TooltipSlowDelay)
-		// ImGui::SetTooltip("%.*s", (int)(label_end - label), label);
-		if (ImGui::IsItemHovered()) {
-			ImGui::SetTooltip("%s", label);
-		}
+		//const bool text_clipped = label_size.x > (ellipsis_max - label_pos.x);
+		// if (text_clipped && hovered && g.ActiveId == 0)
+		// SetItemTooltip("%.*s", (int) (label_end - label), label);
+		if (IsItemHovered()) {
+			SetTooltip("%s", label);
+		}		
 
 		// We don't use BeginPopupContextItem() because we want the popup to stay up even after the column is hidden
-		// if (ImGui::IsMouseReleased(1) && ImGui::IsItemHovered())
-		// ImGui::TableOpenContextMenu(column_n);
+		// if (IsPopupOpenRequestForItem(ImGuiPopupFlags_None, id))
+		// TableOpenContextMenu(column_n);
 	}
 
 	// This code can be used to make the text over the progressBar aligned.

--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -17,6 +17,8 @@
 
 static const float TABLE_BORDER_SIZE = 1.0f; // hardcoded in imgui 1.80 as well
 
+using namespace ImGui;
+
 namespace ImGuiEx {
 	bool Spinner(const char* label, float radius, float thickness, const ImU32& color) {
 		ImGuiWindow* window = ImGui::GetCurrentWindow();
@@ -726,67 +728,135 @@ namespace ImGuiEx {
 		return startPos.x != endPos.x || startPos.y != endPos.y;
 	}
 
+	// Store ImGuiTreeNodeStackData for just submitted node.
+	// Currently only supports 32 level deep and we are fine with (1 << Depth) overflowing into a zero, easy to increase.
+	static void TreeNodeStoreStackData(ImGuiTreeNodeFlags flags, float x1)
+	{
+		ImGuiContext& g = *GImGui;
+		ImGuiWindow* window = g.CurrentWindow;
+
+		g.TreeNodeStack.resize(g.TreeNodeStack.Size + 1);
+		ImGuiTreeNodeStackData* tree_node_data = &g.TreeNodeStack.Data[g.TreeNodeStack.Size - 1];
+		tree_node_data->ID = g.LastItemData.ID;
+		tree_node_data->TreeFlags = flags;
+		tree_node_data->ItemFlags = g.LastItemData.ItemFlags;
+		tree_node_data->NavRect = g.LastItemData.NavRect;
+
+		// Initially I tried to latch value for GetColorU32(ImGuiCol_TreeLines) but it's not a good trade-off for very large trees.
+		const bool draw_lines = (flags & (ImGuiTreeNodeFlags_DrawLinesFull | ImGuiTreeNodeFlags_DrawLinesToNodes)) != 0;
+		tree_node_data->DrawLinesX1 = draw_lines ? (x1 + g.FontSize * 0.5f + g.Style.FramePadding.x) : +FLT_MAX;
+		tree_node_data->DrawLinesTableColumn = (draw_lines && g.CurrentTable) ? (ImGuiTableColumnIdx) g.CurrentTable->CurrentColumn : -1;
+		tree_node_data->DrawLinesToNodesY2 = -FLT_MAX;
+		window->DC.TreeHasStackDataDepthMask |= (1 << window->DC.TreeDepth);
+		if (flags & ImGuiTreeNodeFlags_DrawLinesToNodes)
+			window->DC.TreeRecordsClippedNodesY2Mask |= (1 << window->DC.TreeDepth);
+	}
+
 	bool TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* label, const char* label_end, void* icon) {
-		ImGuiWindow* window = ImGui::GetCurrentWindow();
+		ImGuiWindow* window = GetCurrentWindow();
 		if (window->SkipItems)
 			return false;
 
 		ImGuiContext& g = *GImGui;
 		const ImGuiStyle& style = g.Style;
+
+		// When not framed, we vertically increase height up to typical framed widget height
 		const bool display_frame = (flags & ImGuiTreeNodeFlags_Framed) != 0;
-		const ImVec2 padding = (display_frame || (flags & ImGuiTreeNodeFlags_FramePadding)) ? style.FramePadding : ImVec2(style.FramePadding.x, ImMin(window->DC.CurrLineTextBaseOffset, style.FramePadding.y));
+		const bool use_frame_padding = (display_frame || (flags & ImGuiTreeNodeFlags_FramePadding));
+		const ImVec2 padding = use_frame_padding ? style.FramePadding : ImVec2(style.FramePadding.x, ImMin(window->DC.CurrLineTextBaseOffset, style.FramePadding.y));
 
 		if (!label_end)
-			label_end = ImGui::FindRenderedTextEnd(label);
-		const ImVec2 label_size = ImGui::CalcTextSize(label, label_end, false);
+			label_end = FindRenderedTextEnd(label);
+		const ImVec2 label_size = CalcTextSize(label, label_end, false);
 
-		// We vertically grow up to current line height up the typical widget height.
-		const float frame_height = ImMax(ImMin(window->DC.CurrLineSize.y, g.FontSize + style.FramePadding.y * 2), label_size.y + padding.y * 2);
+		const float text_offset_x = g.FontSize + (display_frame ? padding.x * 3 : padding.x * 2);                                                           // Collapsing arrow width + Spacing
+		const float text_offset_y = use_frame_padding ? ImMax(style.FramePadding.y, window->DC.CurrLineTextBaseOffset) : window->DC.CurrLineTextBaseOffset; // Latch before ItemSize changes it
+		const float text_width = g.FontSize + label_size.x + padding.x * 2;                                                                                 // Include collapsing arrow
+
+		const float frame_height = label_size.y + padding.y * 2;
+		const bool span_all_columns = (flags & ImGuiTreeNodeFlags_SpanAllColumns) != 0 && (g.CurrentTable != NULL);
+		const bool span_all_columns_label = (flags & ImGuiTreeNodeFlags_LabelSpanAllColumns) != 0 && (g.CurrentTable != NULL);
 		ImRect frame_bb;
-		frame_bb.Min.x = (flags & ImGuiTreeNodeFlags_SpanFullWidth) ? window->WorkRect.Min.x : window->DC.CursorPos.x;
-		frame_bb.Min.y = window->DC.CursorPos.y;
-		frame_bb.Max.x = window->WorkRect.Max.x;
-		frame_bb.Max.y = window->DC.CursorPos.y + frame_height;
+		frame_bb.Min.x = span_all_columns ? window->ParentWorkRect.Min.x : (flags & ImGuiTreeNodeFlags_SpanFullWidth) ? window->WorkRect.Min.x
+																													  : window->DC.CursorPos.x;
+		frame_bb.Min.y = window->DC.CursorPos.y + (text_offset_y - padding.y);
+		frame_bb.Max.x = span_all_columns ? window->ParentWorkRect.Max.x : (flags & ImGuiTreeNodeFlags_SpanLabelWidth) ? window->DC.CursorPos.x + text_width + padding.x
+																													   : window->WorkRect.Max.x;
+		frame_bb.Max.y = window->DC.CursorPos.y + (text_offset_y - padding.y) + frame_height;
 		if (display_frame) {
-			// Framed header expand a little outside the default padding, to the edge of InnerClipRect
-			// (FIXME: May remove this at some point and make InnerClipRect align with WindowPadding.x instead of WindowPadding.x*0.5f)
-			frame_bb.Min.x -= IM_TRUNC(window->WindowPadding.x * 0.5f - 1.0f);
-			frame_bb.Max.x += IM_TRUNC(window->WindowPadding.x * 0.5f);
+			const float outer_extend = IM_TRUNC(window->WindowPadding.x * 0.5f); // Framed header expand a little outside of current limits
+			frame_bb.Min.x -= outer_extend;
+			frame_bb.Max.x += outer_extend;
 		}
 
-		const float text_offset_x = g.FontSize + (display_frame ? padding.x * 3 : padding.x * 2);          // Collapser arrow width + Spacing
-		const float text_offset_y = ImMax(padding.y, window->DC.CurrLineTextBaseOffset);                   // Latch before ItemSize changes it
-		const float text_width = g.FontSize + (label_size.x > 0.0f ? label_size.x + padding.x * 2 : 0.0f); // Include collapser
 		ImVec2 text_pos(window->DC.CursorPos.x + text_offset_x, window->DC.CursorPos.y + text_offset_y);
-		ImGui::ItemSize(ImVec2(text_width, frame_height), padding.y);
+		ItemSize(ImVec2(text_width, frame_height), padding.y);
 
 		// For regular tree nodes, we arbitrary allow to click past 2 worth of ItemSpacing
 		ImRect interact_bb = frame_bb;
-		if (!display_frame && (flags & (ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_SpanFullWidth)) == 0)
-			interact_bb.Max.x = frame_bb.Min.x + text_width + style.ItemSpacing.x * 2.0f;
+		if ((flags & (ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_SpanFullWidth | ImGuiTreeNodeFlags_SpanLabelWidth | ImGuiTreeNodeFlags_SpanAllColumns)) == 0)
+			interact_bb.Max.x = frame_bb.Min.x + text_width + (label_size.x > 0.0f ? style.ItemSpacing.x * 2.0f : 0.0f);
 
-		// Store a flag for the current depth to tell if we will allow closing this node when navigating one of its child.
+		// Compute open and multi-select states before ItemAdd() as it clear NextItem data.
+		ImGuiID storage_id = (g.NextItemData.HasFlags & ImGuiNextItemDataFlags_HasStorageID) ? g.NextItemData.StorageId : id;
+		bool is_open = TreeNodeUpdateNextOpen(storage_id, flags);
+
+		bool is_visible;
+		if (span_all_columns || span_all_columns_label) {
+			// Modify ClipRect for the ItemAdd(), faster than doing a PushColumnsBackground/PushTableBackgroundChannel for every Selectable..
+			const float backup_clip_rect_min_x = window->ClipRect.Min.x;
+			const float backup_clip_rect_max_x = window->ClipRect.Max.x;
+			window->ClipRect.Min.x = window->ParentWorkRect.Min.x;
+			window->ClipRect.Max.x = window->ParentWorkRect.Max.x;
+			is_visible = ItemAdd(interact_bb, id);
+			window->ClipRect.Min.x = backup_clip_rect_min_x;
+			window->ClipRect.Max.x = backup_clip_rect_max_x;
+		} else {
+			is_visible = ItemAdd(interact_bb, id);
+		}
+		g.LastItemData.StatusFlags |= ImGuiItemStatusFlags_HasDisplayRect;
+		g.LastItemData.DisplayRect = frame_bb;
+
+		// If a NavLeft request is happening and ImGuiTreeNodeFlags_NavLeftJumpsToParent enabled:
+		// Store data for the current depth to allow returning to this node from any child item.
 		// For this purpose we essentially compare if g.NavIdIsAlive went from 0 to 1 between TreeNode() and TreePop().
-		// This is currently only support 32 level deep and we are fine with (1 << Depth) overflowing into a zero.
+		// It will become tempting to enable ImGuiTreeNodeFlags_NavLeftJumpsToParent by default or move it to ImGuiStyle.
+		bool store_tree_node_stack_data = false;
+		if ((flags & ImGuiTreeNodeFlags_DrawLinesMask_) == 0)
+			flags |= g.Style.TreeLinesFlags;
+		const bool draw_tree_lines = (flags & (ImGuiTreeNodeFlags_DrawLinesFull | ImGuiTreeNodeFlags_DrawLinesToNodes)) && (frame_bb.Min.y < window->ClipRect.Max.y) && (g.Style.TreeLinesSize > 0.0f);
+		if (!(flags & ImGuiTreeNodeFlags_NoTreePushOnOpen)) {
+			store_tree_node_stack_data = draw_tree_lines;
+			if ((flags & ImGuiTreeNodeFlags_NavLeftJumpsToParent) && !g.NavIdIsAlive)
+				if (g.NavMoveDir == ImGuiDir_Left && g.NavWindow == window && NavMoveRequestButNoResultYet())
+					store_tree_node_stack_data = true;
+		}
+
 		const bool is_leaf = (flags & ImGuiTreeNodeFlags_Leaf) != 0;
-		bool is_open = ImGui::TreeNodeBehaviorIsOpen(id, flags);
-		if (is_open && !g.NavIdIsAlive && (flags & ImGuiTreeNodeFlags_NavLeftJumpsBackHere) && !(flags & ImGuiTreeNodeFlags_NoTreePushOnOpen))
-			window->DC.TreeJumpToParentOnPopMask |= (1 << window->DC.TreeDepth);
-
-		bool item_add = ImGui::ItemAdd(interact_bb, id);
-		window->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_HasDisplayRect;
-		window->DC.LastItemDisplayRect = frame_bb;
-
-		if (!item_add) {
+		if (!is_visible) {
+			if ((flags & ImGuiTreeNodeFlags_DrawLinesToNodes) && (window->DC.TreeRecordsClippedNodesY2Mask & (1 << (window->DC.TreeDepth - 1)))) {
+				ImGuiTreeNodeStackData* parent_data = &g.TreeNodeStack.Data[g.TreeNodeStack.Size - 1];
+				parent_data->DrawLinesToNodesY2 = ImMax(parent_data->DrawLinesToNodesY2, window->DC.CursorPos.y); // Don't need to aim to mid Y position as we are clipped anyway.
+				if (frame_bb.Min.y >= window->ClipRect.Max.y)
+					window->DC.TreeRecordsClippedNodesY2Mask &= ~(1 << (window->DC.TreeDepth - 1)); // Done
+			}
+			if (is_open && store_tree_node_stack_data)
+				TreeNodeStoreStackData(flags, text_pos.x - text_offset_x); // Call before TreePushOverrideID()
 			if (is_open && !(flags & ImGuiTreeNodeFlags_NoTreePushOnOpen))
-				ImGui::TreePushOverrideID(id);
-			IMGUI_TEST_ENGINE_ITEM_INFO(window->DC.LastItemId, label, window->DC.ItemFlags | (is_leaf ? 0 : ImGuiItemStatusFlags_Openable) | (is_open ? ImGuiItemStatusFlags_Opened : 0));
+				TreePushOverrideID(id);
+			IMGUI_TEST_ENGINE_ITEM_INFO(g.LastItemData.ID, label, g.LastItemData.StatusFlags | (is_leaf ? 0 : ImGuiItemStatusFlags_Openable) | (is_open ? ImGuiItemStatusFlags_Opened : 0));
 			return is_open;
 		}
 
+		if (span_all_columns || span_all_columns_label) {
+			TablePushBackgroundChannel();
+			g.LastItemData.StatusFlags |= ImGuiItemStatusFlags_HasClipRect;
+			g.LastItemData.ClipRect = window->ClipRect;
+		}
+
 		ImGuiButtonFlags button_flags = ImGuiTreeNodeFlags_None;
-		if (flags & ImGuiTreeNodeFlags_AllowItemOverlap)
-			button_flags |= ImGuiButtonFlags_AllowItemOverlap;
+		if ((flags & ImGuiTreeNodeFlags_AllowOverlap) || (g.LastItemData.ItemFlags & ImGuiItemFlags_AllowOverlap))
+			button_flags |= ImGuiButtonFlags_AllowOverlap;
 		if (!is_leaf)
 			button_flags |= ImGuiButtonFlags_PressedOnDragDropHold;
 
@@ -796,8 +866,10 @@ namespace ImGuiEx {
 		const float arrow_hit_x1 = (text_pos.x - text_offset_x) - style.TouchExtraPadding.x;
 		const float arrow_hit_x2 = (text_pos.x - text_offset_x) + (g.FontSize + padding.x * 2.0f) + style.TouchExtraPadding.x;
 		const bool is_mouse_x_over_arrow = (g.IO.MousePos.x >= arrow_hit_x1 && g.IO.MousePos.x < arrow_hit_x2);
-		if (window != g.HoveredWindow || !is_mouse_x_over_arrow)
-			button_flags |= ImGuiButtonFlags_NoKeyModifiers;
+
+		const bool is_multi_select = (g.LastItemData.ItemFlags & ImGuiItemFlags_IsMultiSelect) != 0;
+		if (is_multi_select) // We absolutely need to distinguish open vs select so _OpenOnArrow comes by default
+			flags |= (flags & ImGuiTreeNodeFlags_OpenOnMask_) == 0 ? ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick : ImGuiTreeNodeFlags_OpenOnArrow;
 
 		// Open behaviors can be altered with the _OpenOnArrow and _OnOnDoubleClick flags.
 		// Some alteration have subtle effects (e.g. toggle on MouseUp vs MouseDown events) due to requirements for multi-selection and drag and drop support.
@@ -814,109 +886,146 @@ namespace ImGuiEx {
 			button_flags |= ImGuiButtonFlags_PressedOnClickRelease | ImGuiButtonFlags_PressedOnDoubleClick;
 		else
 			button_flags |= ImGuiButtonFlags_PressedOnClickRelease;
+		if (flags & ImGuiTreeNodeFlags_NoNavFocus)
+			button_flags |= ImGuiButtonFlags_NoNavFocus;
 
 		bool selected = (flags & ImGuiTreeNodeFlags_Selected) != 0;
 		const bool was_selected = selected;
 
+		// Multi-selection support (header)
+		if (is_multi_select) {
+			// Handle multi-select + alter button flags for it
+			MultiSelectItemHeader(id, &selected, &button_flags);
+			if (is_mouse_x_over_arrow)
+				button_flags = (button_flags | ImGuiButtonFlags_PressedOnClick) & ~ImGuiButtonFlags_PressedOnClickRelease;
+		} else {
+			if (window != g.HoveredWindow || !is_mouse_x_over_arrow)
+				button_flags |= ImGuiButtonFlags_NoKeyModsAllowed;
+		}
+
 		bool hovered, held;
-		bool pressed = ImGui::ButtonBehavior(interact_bb, id, &hovered, &held, button_flags);
+		bool pressed = ButtonBehavior(interact_bb, id, &hovered, &held, button_flags);
 		bool toggled = false;
 		if (!is_leaf) {
 			if (pressed && g.DragDropHoldJustPressedId != id) {
-				if ((flags & (ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick)) == 0 || (g.NavActivateId == id))
-					toggled = true;
+				if ((flags & ImGuiTreeNodeFlags_OpenOnMask_) == 0 || (g.NavActivateId == id && !is_multi_select))
+					toggled = true; // Single click
 				if (flags & ImGuiTreeNodeFlags_OpenOnArrow)
-					toggled |= is_mouse_x_over_arrow && !g.NavDisableMouseHover; // Lightweight equivalent of IsMouseHoveringRect() since ButtonBehavior() already did the job
-				if ((flags & ImGuiTreeNodeFlags_OpenOnDoubleClick) && g.IO.MouseDoubleClicked[0])
-					toggled = true;
+					toggled |= is_mouse_x_over_arrow && !g.NavHighlightItemUnderNav; // Lightweight equivalent of IsMouseHoveringRect() since ButtonBehavior() already did the job
+				if ((flags & ImGuiTreeNodeFlags_OpenOnDoubleClick) && g.IO.MouseClickedCount[0] == 2)
+					toggled = true; // Double click
 			} else if (pressed && g.DragDropHoldJustPressedId == id) {
 				IM_ASSERT(button_flags & ImGuiButtonFlags_PressedOnDragDropHold);
 				if (!is_open) // When using Drag and Drop "hold to open" we keep the node highlighted after opening, but never close it again.
 					toggled = true;
+				else
+					pressed = false; // Cancel press so it doesn't trigger selection.
 			}
 
-			if (g.NavId == id && g.NavMoveRequest && g.NavMoveDir == ImGuiDir_Left && is_open) {
+			if (g.NavId == id && g.NavMoveDir == ImGuiDir_Left && is_open) {
 				toggled = true;
-				ImGui::NavMoveRequestCancel();
+				NavClearPreferredPosForAxis(ImGuiAxis_X);
+				NavMoveRequestCancel();
 			}
-			if (g.NavId == id && g.NavMoveRequest && g.NavMoveDir == ImGuiDir_Right && !is_open) // If there's something upcoming on the line we may want to give it the priority?
+			if (g.NavId == id && g.NavMoveDir == ImGuiDir_Right && !is_open) // If there's something upcoming on the line we may want to give it the priority?
 			{
 				toggled = true;
-				ImGui::NavMoveRequestCancel();
+				NavClearPreferredPosForAxis(ImGuiAxis_X);
+				NavMoveRequestCancel();
 			}
 
 			if (toggled) {
 				is_open = !is_open;
-				window->DC.StateStorage->SetInt(id, is_open);
-				window->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_ToggledOpen;
+				window->DC.StateStorage->SetInt(storage_id, is_open);
+				g.LastItemData.StatusFlags |= ImGuiItemStatusFlags_ToggledOpen;
 			}
 		}
-		if (flags & ImGuiTreeNodeFlags_AllowItemOverlap)
-			ImGui::SetItemAllowOverlap();
 
-		// In this branch, TreeNodeBehavior() cannot toggle the selection so this will never trigger.
-		if (selected != was_selected) //-V547
-			window->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_ToggledSelection;
+		// Multi-selection support (footer)
+		if (is_multi_select) {
+			bool pressed_copy = pressed && !toggled;
+			MultiSelectItemFooter(id, &selected, &pressed_copy);
+			if (pressed)
+				SetNavID(id, window->DC.NavLayerCurrent, g.CurrentFocusScopeId, interact_bb);
+		}
+
+		if (selected != was_selected)
+			g.LastItemData.StatusFlags |= ImGuiItemStatusFlags_ToggledSelection;
 
 		// Render
-		const ImU32 text_col = ImGui::GetColorU32(ImGuiCol_Text);
-		ImGuiNavHighlightFlags nav_highlight_flags = ImGuiNavHighlightFlags_TypeThin;
-		if (display_frame) {
-			// Framed type
-			const ImU32 bg_col = ImGui::GetColorU32((held && hovered) ? ImGuiCol_HeaderActive : hovered ? ImGuiCol_HeaderHovered
-																										: ImGuiCol_Header);
-			ImGui::RenderFrame(frame_bb.Min, frame_bb.Max, bg_col, true, style.FrameRounding);
-			ImGui::RenderNavHighlight(frame_bb, id, nav_highlight_flags);
-			if (flags & ImGuiTreeNodeFlags_Bullet)
-				ImGui::RenderBullet(window->DrawList, ImVec2(text_pos.x - text_offset_x * 0.60f, text_pos.y + g.FontSize * 0.5f), text_col);
-			else if (!is_leaf)
-				ImGui::RenderArrow(window->DrawList, ImVec2(text_pos.x - text_offset_x + padding.x, text_pos.y), text_col, is_open ? ImGuiDir_Down : ImGuiDir_Right, 1.0f);
-			else // Leaf without bullet, left-adjusted text
-				text_pos.x -= text_offset_x;
-			if (icon) {
-				float size = ImGui::GetFontSize();
-				ImGui::Image(icon, ImVec2(size, size));
-				ImGui::SameLine();
-			}
-			if (flags & ImGuiTreeNodeFlags_ClipLabelForTrailingButton)
-				frame_bb.Max.x -= g.FontSize + style.FramePadding.x;
-			if (g.LogEnabled) {
-				// NB: '##' is normally used to hide text (as a library-wide feature), so we need to specify the text range to make sure the ## aren't stripped out here.
-				const char log_prefix[] = "\n##";
-				const char log_suffix[] = "##";
-				ImGui::LogRenderedText(&text_pos, log_prefix, log_prefix + 3);
-				ImGui::RenderTextClipped(text_pos, frame_bb.Max, label, label_end, &label_size);
-				ImGui::LogRenderedText(&text_pos, log_suffix, log_suffix + 2);
+		{
+			const ImU32 text_col = GetColorU32(ImGuiCol_Text);
+			ImGuiNavRenderCursorFlags nav_render_cursor_flags = ImGuiNavRenderCursorFlags_Compact;
+			if (is_multi_select)
+				nav_render_cursor_flags |= ImGuiNavRenderCursorFlags_AlwaysDraw; // Always show the nav rectangle
+			if (display_frame) {
+				// Framed type
+				const ImU32 bg_col = GetColorU32((held && hovered) ? ImGuiCol_HeaderActive : hovered ? ImGuiCol_HeaderHovered
+																									 : ImGuiCol_Header);
+				RenderFrame(frame_bb.Min, frame_bb.Max, bg_col, true, style.FrameRounding);
+				RenderNavCursor(frame_bb, id, nav_render_cursor_flags);
+				if (span_all_columns && !span_all_columns_label)
+					TablePopBackgroundChannel();
+				if (flags & ImGuiTreeNodeFlags_Bullet)
+					RenderBullet(window->DrawList, ImVec2(text_pos.x - text_offset_x * 0.60f, text_pos.y + g.FontSize * 0.5f), text_col);
+				else if (!is_leaf)
+					RenderArrow(window->DrawList, ImVec2(text_pos.x - text_offset_x + padding.x, text_pos.y), text_col, is_open ? ((flags & ImGuiTreeNodeFlags_UpsideDownArrow) ? ImGuiDir_Up : ImGuiDir_Down) : ImGuiDir_Right, 1.0f);
+				else // Leaf without bullet, left-adjusted text
+					text_pos.x -= text_offset_x - padding.x;
+
+				if (icon) {
+					float size = GetFontSize();
+					Image(icon, ImVec2(size, size));
+					SameLine();
+				}
+
+				if (flags & ImGuiTreeNodeFlags_ClipLabelForTrailingButton)
+					frame_bb.Max.x -= g.FontSize + style.FramePadding.x;
+				if (g.LogEnabled)
+					LogSetNextTextDecoration("###", "###");
 			} else {
-				ImGui::RenderTextClipped(text_pos, frame_bb.Max, label, label_end, &label_size);
-			}
-		} else {
-			// Unframed typed for tree nodes
-			if (hovered || selected) {
-				const ImU32 bg_col = ImGui::GetColorU32((held && hovered) ? ImGuiCol_HeaderActive : hovered ? ImGuiCol_HeaderHovered
-																											: ImGuiCol_Header);
-				ImGui::RenderFrame(frame_bb.Min, frame_bb.Max, bg_col, false);
-				ImGui::RenderNavHighlight(frame_bb, id, nav_highlight_flags);
-			}
-			if (flags & ImGuiTreeNodeFlags_Bullet)
-				ImGui::RenderBullet(window->DrawList, ImVec2(text_pos.x - text_offset_x * 0.5f, text_pos.y + g.FontSize * 0.5f), text_col);
-			else if (!is_leaf)
-				ImGui::RenderArrow(window->DrawList, ImVec2(text_pos.x - text_offset_x + padding.x, text_pos.y + g.FontSize * 0.15f), text_col, is_open ? ImGuiDir_Down : ImGuiDir_Right, 0.70f);
-			if (g.LogEnabled)
-				ImGui::LogRenderedText(&text_pos, ">");
+				// Unframed typed for tree nodes
+				if (hovered || selected) {
+					const ImU32 bg_col = GetColorU32((held && hovered) ? ImGuiCol_HeaderActive : hovered ? ImGuiCol_HeaderHovered
+																										 : ImGuiCol_Header);
+					RenderFrame(frame_bb.Min, frame_bb.Max, bg_col, false);
+				}
+				RenderNavCursor(frame_bb, id, nav_render_cursor_flags);
+				if (span_all_columns && !span_all_columns_label)
+					TablePopBackgroundChannel();
+				if (flags & ImGuiTreeNodeFlags_Bullet)
+					RenderBullet(window->DrawList, ImVec2(text_pos.x - text_offset_x * 0.5f, text_pos.y + g.FontSize * 0.5f), text_col);
+				else if (!is_leaf)
+					RenderArrow(window->DrawList, ImVec2(text_pos.x - text_offset_x + padding.x, text_pos.y + g.FontSize * 0.15f), text_col, is_open ? ((flags & ImGuiTreeNodeFlags_UpsideDownArrow) ? ImGuiDir_Up : ImGuiDir_Down) : ImGuiDir_Right, 0.70f);
+				if (g.LogEnabled)
+					LogSetNextTextDecoration(">", NULL);				
 
-			if (icon) {
-				float size = ImGui::GetFontSize();
-				ImGui::Image(icon, ImVec2(size, size));
-				ImGui::SameLine();
+				if (icon) {
+					float size = GetFontSize();
+					Image(icon, ImVec2(size, size));
+					SameLine();
+				}
 			}
 
-			ImGui::RenderText(text_pos, label, label_end, false);
+			if (draw_tree_lines)
+				TreeNodeDrawLineToChildNode(ImVec2(text_pos.x - text_offset_x + padding.x, text_pos.y + g.FontSize * 0.5f));
+
+			// Label
+			if (display_frame)
+				RenderTextClipped(text_pos, frame_bb.Max, label, label_end, &label_size);
+			else
+				RenderText(text_pos, label, label_end, false);
+
+			if (span_all_columns_label)
+				TablePopBackgroundChannel();
 		}
 
+		if (is_open && store_tree_node_stack_data)
+			TreeNodeStoreStackData(flags, text_pos.x - text_offset_x); // Call before TreePushOverrideID()
 		if (is_open && !(flags & ImGuiTreeNodeFlags_NoTreePushOnOpen))
-			ImGui::TreePushOverrideID(id);
-		IMGUI_TEST_ENGINE_ITEM_INFO(id, label, window->DC.ItemFlags | (is_leaf ? 0 : ImGuiItemStatusFlags_Openable) | (is_open ? ImGuiItemStatusFlags_Opened : 0));
+			TreePushOverrideID(id); // Could use TreePush(label) but this avoid computing twice
+
+		IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.LastItemData.StatusFlags | (is_leaf ? 0 : ImGuiItemStatusFlags_Openable) | (is_open ? ImGuiItemStatusFlags_Opened : 0));
 		return is_open;
 	}
 

--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -444,20 +444,20 @@ namespace ImGuiEx {
 			// Menu inside an horizontal menu bar
 			// Selectable extend their highlight by half ItemSpacing in each direction.
 			// For ChildMenu, the popup position will be overwritten by the call to FindBestWindowPosForPopup() in Begin()
-			popup_pos = ImVec2(pos.x - 1.0f - IM_FLOOR(style.ItemSpacing.x * 0.5f), pos.y - style.FramePadding.y + window->MenuBarHeight());
-			window->DC.CursorPos.x += IM_FLOOR(style.ItemSpacing.x * 0.5f);
+			popup_pos = ImVec2(pos.x - 1.0f - IM_TRUNC(style.ItemSpacing.x * 0.5f), pos.y - style.FramePadding.y + window->MenuBarHeight());
+			window->DC.CursorPos.x += IM_TRUNC(style.ItemSpacing.x * 0.5f);
 			ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(style.ItemSpacing.x * 2.0f, style.ItemSpacing.y));
 			float w = label_size.x;
 			pressed = ImGui::Selectable(label, menu_is_open, ImGuiSelectableFlags_NoHoldingActiveID | ImGuiSelectableFlags_SelectOnClick | ImGuiSelectableFlags_DontClosePopups | (!enabled ? ImGuiSelectableFlags_Disabled : 0), ImVec2(w, 0.0f));
 			ImGui::PopStyleVar();
-			window->DC.CursorPos.x += IM_FLOOR(style.ItemSpacing.x * (-1.0f + 0.5f));
+			window->DC.CursorPos.x += IM_TRUNC(style.ItemSpacing.x * (-1.0f + 0.5f));
 			// -1 spacing to compensate the spacing added when Selectable() did a SameLine(). It would also work to call SameLine() ourselves after the PopStyleVar().
 		} else {
 			// Menu inside a menu
 			// (In a typical menu window where all items are BeginMenu() or MenuItem() calls, extra_w will always be 0.0f.
 			//  Only when they are other items sticking out we're going to add spacing, yet only register minimum width into the layout system.
 			popup_pos = ImVec2(pos.x, pos.y - style.WindowPadding.y);
-			float min_w = window->DC.MenuColumns.DeclColumns(label_size.x, 0.0f, IM_FLOOR(g.FontSize * 1.20f)); // Feedback to next frame
+			float min_w = window->DC.MenuColumns.DeclColumns(label_size.x, 0.0f, IM_TRUNC(g.FontSize * 1.20f)); // Feedback to next frame
 			float extra_w = ImMax(0.0f, ImGui::GetContentRegionAvail().x - min_w);
 			pressed = ImGui::Selectable(label, menu_is_open, ImGuiSelectableFlags_NoHoldingActiveID | ImGuiSelectableFlags_SelectOnClick | ImGuiSelectableFlags_DontClosePopups | ImGuiSelectableFlags_SpanAvailWidth | (!enabled ? ImGuiSelectableFlags_Disabled : 0), ImVec2(min_w, 0.0f));
 			ImU32 text_col = ImGui::GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled);
@@ -750,8 +750,8 @@ namespace ImGuiEx {
 		if (display_frame) {
 			// Framed header expand a little outside the default padding, to the edge of InnerClipRect
 			// (FIXME: May remove this at some point and make InnerClipRect align with WindowPadding.x instead of WindowPadding.x*0.5f)
-			frame_bb.Min.x -= IM_FLOOR(window->WindowPadding.x * 0.5f - 1.0f);
-			frame_bb.Max.x += IM_FLOOR(window->WindowPadding.x * 0.5f);
+			frame_bb.Min.x -= IM_TRUNC(window->WindowPadding.x * 0.5f - 1.0f);
+			frame_bb.Max.x += IM_TRUNC(window->WindowPadding.x * 0.5f);
 		}
 
 		const float text_offset_x = g.FontSize + (display_frame ? padding.x * 3 : padding.x * 2);          // Collapser arrow width + Spacing

--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -324,7 +324,7 @@ namespace ImGuiEx {
 	// This code can be used to make the text over the progressBar aligned.
 	// This also uses imgui internals, which are likely to change between versions.
 	void AlignedProgressBar(float fraction, const ImVec2& size_arg, const char* overlay, Alignment alignment) {
-		ImGuiWindow* window = ImGui::GetCurrentWindow();
+		ImGuiWindow* window = GetCurrentWindow();
 		if (window->SkipItems)
 			return;
 
@@ -332,43 +332,66 @@ namespace ImGuiEx {
 		const ImGuiStyle& style = g.Style;
 
 		ImVec2 pos = window->DC.CursorPos;
-		ImVec2 size = ImGui::CalcItemSize(size_arg, ImGui::CalcItemWidth(), g.FontSize + style.FramePadding.y * 2.0f);
+		ImVec2 size = CalcItemSize(size_arg, CalcItemWidth(), g.FontSize + style.FramePadding.y * 2.0f);
 		ImRect bb(pos, pos + size);
-		ImGui::ItemSize(size, style.FramePadding.y);
-		if (!ImGui::ItemAdd(bb, 0))
+		ItemSize(size, style.FramePadding.y);
+		if (!ItemAdd(bb, 0))
 			return;
 
-		// Render
-		fraction = ImSaturate(fraction);
-		ImGui::RenderFrame(bb.Min, bb.Max, ImGui::GetColorU32(ImGuiCol_FrameBg), true, style.FrameRounding);
-		bb.Expand(ImVec2(-style.FrameBorderSize, -style.FrameBorderSize));
-		const ImVec2 fill_br = ImVec2(ImLerp(bb.Min.x, bb.Max.x, fraction), bb.Max.y);
-		ImGui::RenderRectFilledRangeH(window->DrawList, bb, ImGui::GetColorU32(ImGuiCol_PlotHistogram), 0.0f, fraction, style.FrameRounding);
+		// Fraction < 0.0f will display an indeterminate progress bar animation
+		// The value must be animated along with time, so e.g. passing '-1.0f * ImGui::GetTime()' as fraction works.
+		const bool is_indeterminate = (fraction < 0.0f);
+		if (!is_indeterminate)
+			fraction = ImSaturate(fraction);
 
-		// Default displaying the fraction as percentage string, but user can override it
-		char overlay_buf[32];
-		if (!overlay) {
-			ImFormatString(overlay_buf, IM_ARRAYSIZE(overlay_buf), "%.0f%%", fraction * 100 + 0.01f);
-			overlay = overlay_buf;
+		// Out of courtesy we accept a NaN fraction without crashing
+		float fill_n0 = 0.0f;
+		float fill_n1 = (fraction == fraction) ? fraction : 0.0f;
+
+		if (is_indeterminate) {
+			const float fill_width_n = 0.2f;
+			fill_n0 = ImFmod(-fraction, 1.0f) * (1.0f + fill_width_n) - fill_width_n;
+			fill_n1 = ImSaturate(fill_n0 + fill_width_n);
+			fill_n0 = ImSaturate(fill_n0);
 		}
 
-		ImVec2 overlay_size = ImGui::CalcTextSize(overlay, NULL);
-		if (overlay_size.x > 0.0f) {
-			switch (alignment) {
-				case Alignment::Left:
-					ImGui::RenderTextClipped(bb.Min, bb.Max, overlay, NULL, &overlay_size, ImVec2(0.f, 0.f), &bb);
-					break;
-				case Alignment::Center:
-					ImGui::RenderTextClipped(bb.Min, bb.Max, overlay, NULL, &overlay_size, ImVec2(0.5f, 0.5f), &bb);
-					break;
-				case Alignment::Right:
-					ImGui::RenderTextClipped(bb.Min, bb.Max, overlay, NULL, &overlay_size, ImVec2(1.f, 0.f), &bb);
-					break;
-				default:
-					ImGui::RenderTextClipped(
-							ImVec2(ImClamp(fill_br.x + style.ItemSpacing.x, bb.Min.x, bb.Max.x - overlay_size.x - style.ItemInnerSpacing.x), bb.Min.y), bb.Max,
-							overlay, NULL, &overlay_size, ImVec2(0.0f, 0.5f), &bb
-					);
+		// Render
+		RenderFrame(bb.Min, bb.Max, GetColorU32(ImGuiCol_FrameBg), true, style.FrameRounding);
+		bb.Expand(ImVec2(-style.FrameBorderSize, -style.FrameBorderSize));
+		float fill_x0 = ImLerp(bb.Min.x, bb.Max.x, fill_n0);
+		float fill_x1 = ImLerp(bb.Min.x, bb.Max.x, fill_n1);
+		if (fill_x0 < fill_x1)
+			RenderRectFilledInRangeH(window->DrawList, bb, GetColorU32(ImGuiCol_PlotHistogram), fill_x0, fill_x1, style.FrameRounding);
+
+		// Default displaying the fraction as percentage string, but user can override it
+		// Don't display text for indeterminate bars by default
+		char overlay_buf[32];
+		if (!is_indeterminate || overlay != NULL) {
+			if (!overlay) {
+				ImFormatString(overlay_buf, IM_COUNTOF(overlay_buf), "%.0f%%", fraction * 100 + 0.01f);
+				overlay = overlay_buf;
+			}
+
+			ImVec2 overlay_size = CalcTextSize(overlay, NULL);
+			if (overlay_size.x > 0.0f) {
+				ImVec2 alignRender = ImVec2(0.0f, 0.5f);
+				switch (alignment) {
+					case Alignment::Left:
+						alignRender = ImVec2(0.f, 0.f);
+						break;
+					case Alignment::Center:
+						alignRender = ImVec2(0.5f, 0.5f);
+						break;
+					case Alignment::Right:
+						alignRender = ImVec2(1.f, 0.f);
+						break;
+				}
+
+				float text_x = is_indeterminate ? (bb.Min.x + bb.Max.x - overlay_size.x) * 0.5f : fill_x1 + style.ItemSpacing.x;
+				RenderTextClipped(
+						ImVec2(ImClamp(text_x, bb.Min.x, bb.Max.x - overlay_size.x - style.ItemInnerSpacing.x), bb.Min.y), bb.Max,
+						overlay, NULL, &overlay_size, alignRender, &bb
+				);
 			}
 		}
 	}

--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -424,27 +424,54 @@ namespace ImGuiEx {
 		}
 		```
 	 */
-	bool BeginMenu(const char* label, bool enabled, bool& hoveredPar) {
-		ImGuiWindow* window = ImGui::GetCurrentWindow();
+
+	static bool IsRootOfOpenMenuSet()
+	{
+		ImGuiContext& g = *GImGui;
+		ImGuiWindow* window = g.CurrentWindow;
+		if ((g.OpenPopupStack.Size <= g.BeginPopupStack.Size) || (window->Flags & ImGuiWindowFlags_ChildMenu))
+			return false;
+
+		// Initially we used 'upper_popup->OpenParentId == window->IDStack.back()' to differentiate multiple menu sets from each others
+		// (e.g. inside menu bar vs loose menu items) based on parent ID.
+		// This would however prevent the use of e.g. PushID() user code submitting menus.
+		// Previously this worked between popup and a first child menu because the first child menu always had the _ChildWindow flag,
+		// making hovering on parent popup possible while first child menu was focused - but this was generally a bug with other side effects.
+		// Instead we don't treat Popup specifically (in order to consistently support menu features in them), maybe the first child menu of a Popup
+		// doesn't have the _ChildWindow flag, and we rely on this IsRootOfOpenMenuSet() check to allow hovering between root window/popup and first child menu.
+		// In the end, lack of ID check made it so we could no longer differentiate between separate menu sets. To compensate for that, we at least check parent window nav layer.
+		// This fixes the most common case of menu opening on hover when moving between window content and menu bar. Multiple different menu sets in same nav layer would still
+		// open on hover, but that should be a lesser problem, because if such menus are close in proximity in window content then it won't feel weird and if they are far apart
+		// it likely won't be a problem anyone runs into.
+		const ImGuiPopupData* upper_popup = &g.OpenPopupStack[g.BeginPopupStack.Size];
+		if (window->DC.NavLayerCurrent != upper_popup->ParentNavLayer)
+			return false;
+		return upper_popup->Window && (upper_popup->Window->Flags & ImGuiWindowFlags_ChildMenu) && IsWindowChildOf(upper_popup->Window, window, true);
+	}
+
+	bool BeginMenuEx(const char* label, const char* icon, bool enabled, bool& hoveredPar)
+	{
+		ImGuiWindow* window = GetCurrentWindow();
 		if (window->SkipItems)
 			return false;
 
 		ImGuiContext& g = *GImGui;
 		const ImGuiStyle& style = g.Style;
 		const ImGuiID id = window->GetID(label);
-		bool menu_is_open = ImGui::IsPopupOpen(id, ImGuiPopupFlags_None);
+		bool menu_is_open = IsPopupOpen(id, ImGuiPopupFlags_None);
 
 		// Sub-menus are ChildWindow so that mouse can be hovering across them (otherwise top-most popup menu would steal focus and not allow hovering on parent menu)
-		ImGuiWindowFlags flags = ImGuiWindowFlags_ChildMenu | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNavFocus;
-		if (window->Flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_ChildMenu))
-			flags |= ImGuiWindowFlags_ChildWindow;
+		// The first menu in a hierarchy isn't so hovering doesn't get across (otherwise e.g. resizing borders with ImGuiButtonFlags_FlattenChildren would react), but top-most BeginMenu() will bypass that limitation.
+		ImGuiWindowFlags window_flags = ImGuiWindowFlags_ChildMenu | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNavFocus;
+		if (window->Flags & ImGuiWindowFlags_ChildMenu)
+			window_flags |= ImGuiWindowFlags_ChildWindow;
 
 		// If a menu with same the ID was already submitted, we will append to it, matching the behavior of Begin().
 		// We are relying on a O(N) search - so O(N log N) over the frame - which seems like the most efficient for the expected small amount of BeginMenu() calls per frame.
 		// If somehow this is ever becoming a problem we can switch to use e.g. ImGuiStorage mapping key to last frame used.
 		if (g.MenusIdSubmittedThisFrame.contains(id)) {
 			if (menu_is_open)
-				menu_is_open = ImGui::BeginPopupEx(id, flags); // menu_is_open can be 'false' when the popup is completely clipped (e.g. zero size display)
+				menu_is_open = BeginPopupMenuEx(id, label, window_flags); // menu_is_open can be 'false' when the popup is completely clipped (e.g. zero size display)
 			else
 				g.NextWindowData.ClearFlags(); // we behave like Begin() and need to consume those values
 			return menu_is_open;
@@ -453,87 +480,112 @@ namespace ImGuiEx {
 		// Tag menu as used. Next time BeginMenu() with same ID is called it will append to existing menu
 		g.MenusIdSubmittedThisFrame.push_back(id);
 
-		ImVec2 label_size = ImGui::CalcTextSize(label, NULL, true);
-		bool pressed;
-		bool menuset_is_open = !(window->Flags & ImGuiWindowFlags_Popup) && (g.OpenPopupStack.Size > g.BeginPopupStack.Size && g.OpenPopupStack[g.BeginPopupStack.Size].OpenParentId == window->IDStack.back());
-		ImGuiWindow* backed_nav_window = g.NavWindow;
+		ImVec2 label_size = CalcTextSize(label, NULL, true);
+
+		// Odd hack to allow hovering across menus of a same menu-set (otherwise we wouldn't be able to hover parent without always being a Child window)
+		// This is only done for items for the menu set and not the full parent window.
+		const bool menuset_is_open = IsRootOfOpenMenuSet();
 		if (menuset_is_open)
-			g.NavWindow = window; // Odd hack to allow hovering across menus of a same menu-set (otherwise we wouldn't be able to hover parent)
+			PushItemFlag(ImGuiItemFlags_NoWindowHoverableCheck, true);
 
 		// The reference position stored in popup_pos will be used by Begin() to find a suitable position for the child menu,
 		// However the final position is going to be different! It is chosen by FindBestWindowPosForPopup().
 		// e.g. Menus tend to overlap each other horizontally to amplify relative Z-ordering.
-		ImVec2 popup_pos, pos = window->DC.CursorPos;
+		ImVec2 popup_pos;
+		ImVec2 pos = window->DC.CursorPos;
+		PushID(label);
+		if (!enabled)
+			BeginDisabled();
+
+		bool pressed;
+
+		// We use ImGuiSelectableFlags_NoSetKeyOwner to allow down on one menu item, move, up on another.
+		const ImGuiSelectableFlags selectable_flags = ImGuiSelectableFlags_NoHoldingActiveID | ImGuiSelectableFlags_NoSetKeyOwner | ImGuiSelectableFlags_SelectOnClick | ImGuiSelectableFlags_NoAutoClosePopups;
+		ImGuiMenuColumns* offsets = &window->DC.MenuColumns;
 		if (window->DC.LayoutType == ImGuiLayoutType_Horizontal) {
-			// Menu inside an horizontal menu bar
+			// Menu inside a horizontal menu bar
 			// Selectable extend their highlight by half ItemSpacing in each direction.
 			// For ChildMenu, the popup position will be overwritten by the call to FindBestWindowPosForPopup() in Begin()
-			popup_pos = ImVec2(pos.x - 1.0f - IM_TRUNC(style.ItemSpacing.x * 0.5f), pos.y - style.FramePadding.y + window->MenuBarHeight());
 			window->DC.CursorPos.x += IM_TRUNC(style.ItemSpacing.x * 0.5f);
-			ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(style.ItemSpacing.x * 2.0f, style.ItemSpacing.y));
-			float w = label_size.x;
-			pressed = ImGui::Selectable(label, menu_is_open, ImGuiSelectableFlags_NoHoldingActiveID | ImGuiSelectableFlags_SelectOnClick | ImGuiSelectableFlags_DontClosePopups | (!enabled ? ImGuiSelectableFlags_Disabled : 0), ImVec2(w, 0.0f));
-			ImGui::PopStyleVar();
-			window->DC.CursorPos.x += IM_TRUNC(style.ItemSpacing.x * (-1.0f + 0.5f));
-			// -1 spacing to compensate the spacing added when Selectable() did a SameLine(). It would also work to call SameLine() ourselves after the PopStyleVar().
+			PushStyleVarX(ImGuiStyleVar_ItemSpacing, style.ItemSpacing.x * 2.0f);
+			ImVec2 text_pos(window->DC.CursorPos.x + offsets->OffsetLabel, pos.y + window->DC.CurrLineTextBaseOffset);
+			pressed = ImGui::Selectable("", menu_is_open, selectable_flags, label_size);
+			LogSetNextTextDecoration("[", "]");
+			RenderText(text_pos, label);
+			PopStyleVar();
+			window->DC.CursorPos.x += IM_TRUNC(style.ItemSpacing.x * (-1.0f + 0.5f)); // -1 spacing to compensate the spacing added when Selectable() did a SameLine(). It would also work to call SameLine() ourselves after the PopStyleVar().
+			popup_pos = ImVec2(pos.x - 1.0f - IM_TRUNC(style.ItemSpacing.x * 0.5f), text_pos.y - style.FramePadding.y + window->MenuBarHeight);
 		} else {
-			// Menu inside a menu
+			// Menu inside a regular/vertical menu
 			// (In a typical menu window where all items are BeginMenu() or MenuItem() calls, extra_w will always be 0.0f.
-			//  Only when they are other items sticking out we're going to add spacing, yet only register minimum width into the layout system.
-			popup_pos = ImVec2(pos.x, pos.y - style.WindowPadding.y);
-			float min_w = window->DC.MenuColumns.DeclColumns(label_size.x, 0.0f, IM_TRUNC(g.FontSize * 1.20f)); // Feedback to next frame
-			float extra_w = ImMax(0.0f, ImGui::GetContentRegionAvail().x - min_w);
-			pressed = ImGui::Selectable(label, menu_is_open, ImGuiSelectableFlags_NoHoldingActiveID | ImGuiSelectableFlags_SelectOnClick | ImGuiSelectableFlags_DontClosePopups | ImGuiSelectableFlags_SpanAvailWidth | (!enabled ? ImGuiSelectableFlags_Disabled : 0), ImVec2(min_w, 0.0f));
-			ImU32 text_col = ImGui::GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled);
-			ImGui::RenderArrow(window->DrawList, pos + ImVec2(window->DC.MenuColumns.Pos[2] + extra_w + g.FontSize * 0.30f, 0.0f), text_col, ImGuiDir_Right);
+			//  Only when they are other items sticking out we're going to add spacing, yet only register minimum width into the layout system.)
+			float icon_w = (icon && icon[0]) ? CalcTextSize(icon, NULL).x : 0.0f;
+			float checkmark_w = IM_TRUNC(g.FontSize * 1.20f);
+			float min_w = offsets->DeclColumns(icon_w, label_size.x, 0.0f, checkmark_w); // Feedback to next frame
+			float extra_w = ImMax(0.0f, GetContentRegionAvail().x - min_w);
+			ImVec2 text_pos(window->DC.CursorPos.x, pos.y + window->DC.CurrLineTextBaseOffset);
+			pressed = ImGui::Selectable("", menu_is_open, selectable_flags | ImGuiSelectableFlags_SpanAvailWidth, ImVec2(min_w, label_size.y));
+			LogSetNextTextDecoration("", ">");
+			RenderText(ImVec2(text_pos.x + offsets->OffsetLabel, text_pos.y), label);
+			if (icon_w > 0.0f)
+				RenderText(ImVec2(text_pos.x + offsets->OffsetIcon, text_pos.y), icon);
+			RenderArrow(window->DrawList, ImVec2(text_pos.x + offsets->OffsetMark + extra_w + g.FontSize * 0.30f, text_pos.y), GetColorU32(ImGuiCol_Text), ImGuiDir_Right);
+			popup_pos = ImVec2(pos.x, text_pos.y - style.WindowPadding.y);
 		}
+		if (!enabled)
+			EndDisabled();
 
-		const bool hovered = enabled && ImGui::ItemHoverable(window->DC.LastItemRect, id);
+		const bool hovered = (g.HoveredId == id) && enabled && !g.NavHighlightItemUnderNav;
 		hoveredPar = hovered;
 		if (menuset_is_open)
-			g.NavWindow = backed_nav_window;
+			PopItemFlag();
 
 		bool want_open = false;
+		bool want_open_nav_init = false;
 		bool want_close = false;
 		if (window->DC.LayoutType == ImGuiLayoutType_Vertical) // (window->Flags & (ImGuiWindowFlags_Popup|ImGuiWindowFlags_ChildMenu))
 		{
 			// Close menu when not hovering it anymore unless we are moving roughly in the direction of the menu
 			// Implement http://bjk5.com/post/44698559168/breaking-down-amazons-mega-dropdown to avoid using timers, so menus feels more reactive.
-			bool moving_toward_other_child_menu = false;
-
-			ImGuiWindow* child_menu_window = (g.BeginPopupStack.Size < g.OpenPopupStack.Size && g.OpenPopupStack[g.BeginPopupStack.Size].SourceWindow == window)
-													 ? g.OpenPopupStack[g.BeginPopupStack.Size].Window
-													 : NULL;
-			if (g.HoveredWindow == window && child_menu_window != NULL && !(window->Flags & ImGuiWindowFlags_MenuBar)) {
-				// FIXME-DPI: Values should be derived from a master "scale" factor.
-				ImRect next_window_rect = child_menu_window->Rect();
-				ImVec2 ta = g.IO.MousePos - g.IO.MouseDelta;
-				ImVec2 tb = (window->Pos.x < child_menu_window->Pos.x) ? next_window_rect.GetTL() : next_window_rect.GetTR();
-				ImVec2 tc = (window->Pos.x < child_menu_window->Pos.x) ? next_window_rect.GetBL() : next_window_rect.GetBR();
-				float extra = ImClamp(ImFabs(ta.x - tb.x) * 0.30f, 5.0f, 30.0f);    // add a bit of extra slack.
-				ta.x += (window->Pos.x < child_menu_window->Pos.x) ? -0.5f : +0.5f; // to avoid numerical issues
-				tb.y = ta.y + ImMax((tb.y - extra) - ta.y, -100.0f);
-				// triangle is maximum 200 high to limit the slope and the bias toward large sub-menus // FIXME: Multiply by fb_scale?
-				tc.y = ta.y + ImMin((tc.y + extra) - ta.y, +100.0f);
-				moving_toward_other_child_menu = ImTriangleContainsPoint(ta, tb, tc, g.IO.MousePos);
-				//GetForegroundDrawList()->AddTriangleFilled(ta, tb, tc, moving_within_opened_triangle ? IM_COL32(0,128,0,128) : IM_COL32(128,0,0,128)); // [DEBUG]
+			bool moving_toward_child_menu = false;
+			ImGuiPopupData* child_popup = (g.BeginPopupStack.Size < g.OpenPopupStack.Size) ? &g.OpenPopupStack[g.BeginPopupStack.Size] : NULL; // Popup candidate (testing below)
+			ImGuiWindow* child_menu_window = (child_popup && child_popup->Window && child_popup->Window->ParentWindow == window) ? child_popup->Window : NULL;
+			if (g.HoveredWindow == window && child_menu_window != NULL) {
+				const float ref_unit = g.FontSize; // FIXME-DPI
+				const float child_dir = (window->Pos.x < child_menu_window->Pos.x) ? 1.0f : -1.0f;
+				const ImRect next_window_rect = child_menu_window->Rect();
+				ImVec2 ta = (g.IO.MousePos - g.IO.MouseDelta);
+				ImVec2 tb = (child_dir > 0.0f) ? next_window_rect.GetTL() : next_window_rect.GetTR();
+				ImVec2 tc = (child_dir > 0.0f) ? next_window_rect.GetBL() : next_window_rect.GetBR();
+				const float pad_farmost_h = ImClamp(ImFabs(ta.x - tb.x) * 0.30f, ref_unit * 0.5f, ref_unit * 2.5f); // Add a bit of extra slack.
+				ta.x += child_dir * -0.5f;
+				tb.x += child_dir * ref_unit;
+				tc.x += child_dir * ref_unit;
+				tb.y = ta.y + ImMax((tb.y - pad_farmost_h) - ta.y, -ref_unit * 8.0f); // Triangle has maximum height to limit the slope and the bias toward large sub-menus
+				tc.y = ta.y + ImMin((tc.y + pad_farmost_h) - ta.y, +ref_unit * 8.0f);
+				moving_toward_child_menu = ImTriangleContainsPoint(ta, tb, tc, g.IO.MousePos);
+				//GetForegroundDrawList()->AddTriangleFilled(ta, tb, tc, moving_toward_child_menu ? IM_COL32(0,128,0,128) : IM_COL32(128,0,0,128)); // [DEBUG]
 			}
-			if (menu_is_open && !hovered && g.HoveredWindow == window && g.HoveredIdPreviousFrame != 0 && g.HoveredIdPreviousFrame != id && !moving_toward_other_child_menu)
+
+			// The 'HovereWindow == window' check creates an inconsistency (e.g. moving away from menu slowly tends to hit same window, whereas moving away fast does not)
+			// But we also need to not close the top-menu menu when moving over void. Perhaps we should extend the triangle check to a larger polygon.
+			// (Remember to test this on BeginPopup("A")->BeginMenu("B") sequence which behaves slightly differently as B isn't a Child of A and hovering isn't shared.)
+			if (menu_is_open && !hovered && g.HoveredWindow == window && !moving_toward_child_menu && !g.NavHighlightItemUnderNav && g.ActiveId == 0)
 				want_close = true;
 
-			if (!menu_is_open && hovered && pressed) // Click to open
+			// Open
+			// (note: at this point 'hovered' actually includes the NavDisableMouseHover == false test)
+			if (!menu_is_open && pressed) // Click/activate to open
 				want_open = true;
-			else if (!menu_is_open && hovered && !moving_toward_other_child_menu) // Hover to open
+			else if (!menu_is_open && hovered && !moving_toward_child_menu) // Hover to open
 				want_open = true;
-
-			if (g.NavActivateId == id) {
-				want_close = menu_is_open;
-				want_open = !menu_is_open;
-			}
-			if (g.NavId == id && g.NavMoveRequest && g.NavMoveDir == ImGuiDir_Right) // Nav-Right to open
+			else if (!menu_is_open && hovered && g.HoveredIdTimer >= 0.30f && g.MouseStationaryTimer >= 0.30f) // Hover to open (timer fallback)
+				want_open = true;
+			if (g.NavId == id && g.NavMoveDir == ImGuiDir_Right) // Nav-Right to open
 			{
-				want_open = true;
-				ImGui::NavMoveRequestCancel();
+				want_open = want_open_nav_init = true;
+				NavMoveRequestCancel();
+				SetNavCursorVisibleAfterMove();
 			}
 		} else {
 			// Menu bar
@@ -544,39 +596,58 @@ namespace ImGuiEx {
 			} else if (pressed || (hovered && menuset_is_open && !menu_is_open)) // First click to open, then hover to open others
 			{
 				want_open = true;
-			} else if (g.NavId == id && g.NavMoveRequest && g.NavMoveDir == ImGuiDir_Down) // Nav-Down to open
+			} else if (g.NavId == id && g.NavMoveDir == ImGuiDir_Down) // Nav-Down to open
 			{
 				want_open = true;
-				ImGui::NavMoveRequestCancel();
+				NavMoveRequestCancel();
 			}
 		}
 
-		if (!enabled)
-			// explicitly close if an open menu becomes disabled, facilitate users code a lot in pattern such as 'if (BeginMenu("options", has_object)) { ..use object.. }'
+		if (!enabled) // explicitly close if an open menu becomes disabled, facilitate users code a lot in pattern such as 'if (BeginMenu("options", has_object)) { ..use object.. }'
 			want_close = true;
-		if (want_close && ImGui::IsPopupOpen(id, ImGuiPopupFlags_None))
-			ImGui::ClosePopupToLevel(g.BeginPopupStack.Size, true);
+		if (want_close && IsPopupOpen(id, ImGuiPopupFlags_None))
+			ClosePopupToLevel(g.BeginPopupStack.Size, true);
 
-		IMGUI_TEST_ENGINE_ITEM_INFO(id, label, window->DC.ItemFlags | ImGuiItemStatusFlags_Openable | (menu_is_open ? ImGuiItemStatusFlags_Opened : 0));
+		IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.LastItemData.StatusFlags | ImGuiItemStatusFlags_Openable | (menu_is_open ? ImGuiItemStatusFlags_Opened : 0));
+		PopID();
 
-		if (!menu_is_open && want_open && g.OpenPopupStack.Size > g.BeginPopupStack.Size) {
-			// Don't recycle same menu level in the same frame, first close the other menu and yield for a frame.
-			ImGui::OpenPopup(label);
-			return false;
+		if (want_open && !menu_is_open && g.OpenPopupStack.Size > g.BeginPopupStack.Size) {
+			// Don't reopen/recycle same menu level in the same frame if it is a different menu ID, first close the other menu and yield for a frame.
+			OpenPopup(label);
+		} else if (want_open) {
+			menu_is_open = true;
+			OpenPopup(label, ImGuiPopupFlags_NoReopen); // | (want_open_nav_init ? ImGuiPopupFlags_NoReopenAlwaysNavInit : 0));
 		}
 
-		menu_is_open |= want_open;
-		if (want_open)
-			ImGui::OpenPopup(label);
-
 		if (menu_is_open) {
-			ImGui::SetNextWindowPos(popup_pos, ImGuiCond_Always);
-			menu_is_open = ImGui::BeginPopupEx(id, flags); // menu_is_open can be 'false' when the popup is completely clipped (e.g. zero size display)
+			ImGuiLastItemData last_item_in_parent = g.LastItemData;
+			SetNextWindowPos(popup_pos, ImGuiCond_Always);                  // Note: misleading: the value will serve as reference for FindBestWindowPosForPopup(), not actual pos.
+			PushStyleVar(ImGuiStyleVar_ChildRounding, style.PopupRounding); // First level will use _PopupRounding, subsequent will use _ChildRounding
+			menu_is_open = BeginPopupMenuEx(id, label, window_flags);       // menu_is_open may be 'false' when the popup is completely clipped (e.g. zero size display)
+			PopStyleVar();
+			if (menu_is_open) {
+				// Implement what ImGuiPopupFlags_NoReopenAlwaysNavInit would do:
+				// Perform an init request in the case the popup was already open (via a previous mouse hover)
+				if (want_open && want_open_nav_init && !g.NavInitRequest) {
+					FocusWindow(g.CurrentWindow, ImGuiFocusRequestFlags_UnlessBelowModal);
+					NavInitWindow(g.CurrentWindow, false);
+				}
+
+				// Restore LastItemData so IsItemXXXX functions can work after BeginMenu()/EndMenu()
+				// (This fixes using IsItemClicked() and IsItemHovered(), but IsItemHovered() also relies on its support for ImGuiItemFlags_NoWindowHoverableCheck)
+				g.LastItemData = last_item_in_parent;
+				if (g.HoveredWindow == window)
+					g.LastItemData.StatusFlags |= ImGuiItemStatusFlags_HoveredWindow;
+			}
 		} else {
 			g.NextWindowData.ClearFlags(); // We behave like Begin() and need to consume those values
 		}
 
 		return menu_is_open;
+	}
+
+	bool BeginMenu(const char* label, bool enabled, bool& hoveredPar) {
+		return BeginMenuEx(label, NULL, enabled, hoveredPar);
 	}
 
 	void BeginMenuChild(const char* child_str_id, const char* menu_label, std::function<void()> draw_func) {

--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -1170,47 +1170,81 @@ namespace ImGuiEx {
 
 	bool BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width, ImGuiWindowFlags child_window_flags) {
 		ImGuiContext& g = *GImGui;
-		ImGuiWindow* outer_window = ImGui::GetCurrentWindow();
+		ImGuiWindow* outer_window = GetCurrentWindow();
 		if (outer_window->SkipItems) // Consistent with other tables + beneficial side effect that assert on miscalling EndTable() will be more visible.
 			return false;
 
 		// Sanity checks
-		IM_ASSERT(columns_count > 0 && columns_count <= IMGUI_TABLE_MAX_COLUMNS && "Only 1..64 columns allowed!");
+		IM_ASSERT(columns_count > 0 && columns_count < IMGUI_TABLE_MAX_COLUMNS);
 		if (flags & ImGuiTableFlags_ScrollX)
 			IM_ASSERT(inner_width >= 0.0f);
 
-		// If an outer size is specified ahead we will be able to early out when not visible. Exact clipping rules may evolve.
+		// If an outer size is specified ahead we will be able to early out when not visible. Exact clipping criteria may evolve.
+		// FIXME: coarse clipping because access to table data causes two issues:
+		// - instance numbers varying/unstable. may not be a direct problem for users, but could make outside access broken or confusing, e.g. TestEngine.
+		// - can't implement support for ImGuiChildFlags_ResizeY as we need to somehow pull the height data from somewhere. this also needs stable instance numbers.
+		// The side-effects of accessing table data on coarse clip would be:
+		// - always reserving the pooled ImGuiTable data ahead for a fully clipped table (minor IMHO). Also the 'outer_window_is_measuring_size' criteria may already be defeating this in some situations.
+		// - always performing the GetOrAddByKey() O(log N) query in g.Tables.Map[].
 		const bool use_child_window = (flags & (ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY)) != 0;
-		const ImVec2 avail_size = ImGui::GetContentRegionAvail();
-		ImVec2 actual_outer_size = ImGui::CalcItemSize(outer_size, ImMax(avail_size.x, 1.0f), use_child_window ? ImMax(avail_size.y, 1.0f) : 0.0f);
-		ImRect outer_rect(outer_window->DC.CursorPos, outer_window->DC.CursorPos + actual_outer_size);
-		if (use_child_window && ImGui::IsClippedEx(outer_rect, 0, false)) {
-			ImGui::ItemSize(outer_rect);
+		const ImVec2 avail_size = GetContentRegionAvail();
+		const ImVec2 actual_outer_size = ImTrunc(CalcItemSize(outer_size, ImMax(avail_size.x, IMGUI_WINDOW_HARD_MIN_SIZE), use_child_window ? ImMax(avail_size.y, IMGUI_WINDOW_HARD_MIN_SIZE) : 0.0f));
+		const ImRect outer_rect(outer_window->DC.CursorPos, outer_window->DC.CursorPos + actual_outer_size);
+		const bool outer_window_is_measuring_size = (outer_window->AutoFitFramesX > 0) || (outer_window->AutoFitFramesY > 0); // Doesn't apply to AlwaysAutoResize windows!
+		if (use_child_window && IsClippedEx(outer_rect, 0) && !outer_window_is_measuring_size) {
+			ItemSize(outer_rect);
+			ItemAdd(outer_rect, id);
+			g.NextWindowData.ClearFlags();
 			return false;
 		}
 
+		// [DEBUG] Debug break requested by user
+		if (g.DebugBreakInTable == id)
+			IM_DEBUG_BREAK();
+
 		// Acquire storage for the table
 		ImGuiTable* table = g.Tables.GetOrAddByKey(id);
-		const int instance_no = (table->LastFrameActive != g.FrameCount) ? 0 : table->InstanceCurrent + 1;
-		const ImGuiID instance_id = id + instance_no;
-		const ImGuiTableFlags table_last_flags = table->Flags;
-		if (instance_no > 0)
-			IM_ASSERT(table->ColumnsCount == columns_count && "BeginTable(): Cannot change columns count mid-frame while preserving same ID");
+
+		// Acquire temporary buffers
+		const int table_idx = g.Tables.GetIndex(table);
+		if (++g.TablesTempDataStacked > g.TablesTempData.Size)
+			g.TablesTempData.resize(g.TablesTempDataStacked, ImGuiTableTempData());
+		ImGuiTableTempData* temp_data = table->TempData = &g.TablesTempData[g.TablesTempDataStacked - 1];
+		temp_data->TableIndex = table_idx;
+		table->DrawSplitter = &table->TempData->DrawSplitter;
+		table->DrawSplitter->Clear();
 
 		// Fix flags
 		table->IsDefaultSizingPolicy = (flags & ImGuiTableFlags_SizingMask_) == 0;
 		flags = TableFixFlags(flags, outer_window);
 
 		// Initialize
+		const int previous_frame_active = table->LastFrameActive;
+		const int instance_no = (previous_frame_active != g.FrameCount) ? 0 : table->InstanceCurrent + 1;
+		const ImGuiTableFlags previous_flags = table->Flags;
 		table->ID = id;
 		table->Flags = flags;
-		table->InstanceCurrent = (ImS16) instance_no;
 		table->LastFrameActive = g.FrameCount;
 		table->OuterWindow = table->InnerWindow = outer_window;
 		table->ColumnsCount = columns_count;
 		table->IsLayoutLocked = false;
 		table->InnerWidth = inner_width;
-		table->UserOuterSize = outer_size;
+		table->NavLayer = (ImS8) outer_window->DC.NavLayerCurrent;
+		temp_data->UserOuterSize = outer_size;
+
+		// Instance data (for instance 0, TableID == TableInstanceID)
+		ImGuiID instance_id;
+		table->InstanceCurrent = (ImS16) instance_no;
+		if (instance_no > 0) {
+			IM_ASSERT(table->ColumnsCount == columns_count && "BeginTable(): Cannot change columns count mid-frame while preserving same ID");
+			if (table->InstanceDataExtra.Size < instance_no)
+				table->InstanceDataExtra.push_back(ImGuiTableInstanceData());
+			instance_id = GetIDWithSeed(instance_no, GetIDWithSeed("##Instances", NULL, id)); // Push "##Instances" followed by (int)instance_no in ID stack.
+		} else {
+			instance_id = id;
+		}
+		ImGuiTableInstanceData* table_instance = TableGetInstanceData(table, table->InstanceCurrent);
+		table_instance->TableInstanceID = instance_id;
 
 		// When not using a child window, WorkRect.Max will grow as we append contents.
 		if (use_child_window) {
@@ -1228,44 +1262,83 @@ namespace ImGuiEx {
 				override_content_size.x = inner_width;
 
 			if (override_content_size.x != FLT_MAX || override_content_size.y != FLT_MAX)
-				ImGui::SetNextWindowContentSize(ImVec2(override_content_size.x != FLT_MAX ? override_content_size.x : 0.0f, override_content_size.y != FLT_MAX ? override_content_size.y : 0.0f));
+				SetNextWindowContentSize(ImVec2(override_content_size.x != FLT_MAX ? override_content_size.x : 0.0f, override_content_size.y != FLT_MAX ? override_content_size.y : 0.0f));
 
 			// Reset scroll if we are reactivating it
-			if ((table_last_flags & (ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY)) == 0)
-				ImGui::SetNextWindowScroll(ImVec2(0.0f, 0.0f));
+			if ((previous_flags & (ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY)) == 0)
+				if ((g.NextWindowData.HasFlags & ImGuiNextWindowDataFlags_HasScroll) == 0)
+					SetNextWindowScroll(ImVec2(0.0f, 0.0f));
 
 			// Create scrolling region (without border and zero window padding)
-			ImGuiWindowFlags child_flags = child_window_flags;
-			child_flags |= (flags & ImGuiTableFlags_ScrollX) ? ImGuiWindowFlags_HorizontalScrollbar : ImGuiWindowFlags_None;
-			ImGui::BeginChildEx(name, instance_id, outer_rect.GetSize(), false, child_flags);
+			ImGuiChildFlags child_child_flags = (g.NextWindowData.HasFlags & ImGuiNextWindowDataFlags_HasChildFlags) ? g.NextWindowData.ChildFlags : ImGuiChildFlags_None;
+			child_window_flags |= (g.NextWindowData.HasFlags & ImGuiNextWindowDataFlags_HasWindowFlags) ? g.NextWindowData.WindowFlags : ImGuiWindowFlags_None;
+			if (flags & ImGuiTableFlags_ScrollX)
+				child_window_flags |= ImGuiWindowFlags_HorizontalScrollbar;
+			BeginChildEx(name, instance_id, outer_rect.GetSize(), child_child_flags, child_window_flags);
 			table->InnerWindow = g.CurrentWindow;
 			table->WorkRect = table->InnerWindow->WorkRect;
 			table->OuterRect = table->InnerWindow->Rect();
 			table->InnerRect = table->InnerWindow->InnerRect;
 			IM_ASSERT(table->InnerWindow->WindowPadding.x == 0.0f && table->InnerWindow->WindowPadding.y == 0.0f && table->InnerWindow->WindowBorderSize == 0.0f);
+
+			// Allow submitting when host is measuring
+			if (table->InnerWindow->SkipItems && outer_window_is_measuring_size)
+				table->InnerWindow->SkipItems = false;
+
+			// When using multiple instances, ensure they have the same amount of horizontal decorations (aka vertical scrollbar) so stretched columns can be aligned
+			if (instance_no == 0) {
+				table->HasScrollbarYPrev = table->HasScrollbarYCurr;
+				table->HasScrollbarYCurr = false;
+			}
+			table->HasScrollbarYCurr |= table->InnerWindow->ScrollbarY;
 		} else {
 			// For non-scrolling tables, WorkRect == OuterRect == InnerRect.
 			// But at this point we do NOT have a correct value for .Max.y (unless a height has been explicitly passed in). It will only be updated in EndTable().
 			table->WorkRect = table->OuterRect = table->InnerRect = outer_rect;
+			table->HasScrollbarYPrev = table->HasScrollbarYCurr = false;
+			table->InnerWindow->DC.TreeDepth++; // This is designed to always linking ImGuiTreeNodeFlags_DrawLines linking across a table
 		}
 
 		// Push a standardized ID for both child-using and not-child-using tables
-		ImGui::PushOverrideID(instance_id);
+		PushOverrideID(id);
+		if (instance_no > 0)
+			PushOverrideID(instance_id); // FIXME: Somehow this is not resolved by stack-tool, even tho GetIDWithSeed() submitted the symbol.
 
 		// Backup a copy of host window members we will modify
 		ImGuiWindow* inner_window = table->InnerWindow;
 		table->HostIndentX = inner_window->DC.Indent.x;
 		table->HostClipRect = inner_window->ClipRect;
 		table->HostSkipItems = inner_window->SkipItems;
-		table->HostBackupWorkRect = inner_window->WorkRect;
-		table->HostBackupParentWorkRect = inner_window->ParentWorkRect;
-		table->HostBackupColumnsOffset = outer_window->DC.ColumnsOffset;
-		table->HostBackupPrevLineSize = inner_window->DC.PrevLineSize;
-		table->HostBackupCurrLineSize = inner_window->DC.CurrLineSize;
-		table->HostBackupCursorMaxPos = inner_window->DC.CursorMaxPos;
-		table->HostBackupItemWidth = outer_window->DC.ItemWidth;
-		table->HostBackupItemWidthStackSize = outer_window->DC.ItemWidthStack.Size;
+		temp_data->WindowID = inner_window->ID;
+		temp_data->HostBackupWorkRect = inner_window->WorkRect;
+		temp_data->HostBackupParentWorkRect = inner_window->ParentWorkRect;
+		temp_data->HostBackupColumnsOffset = outer_window->DC.ColumnsOffset;
+		temp_data->HostBackupPrevLineSize = inner_window->DC.PrevLineSize;
+		temp_data->HostBackupCurrLineSize = inner_window->DC.CurrLineSize;
+		temp_data->HostBackupCursorMaxPos = inner_window->DC.CursorMaxPos;
+		temp_data->HostBackupItemWidth = outer_window->DC.ItemWidth;
+		temp_data->HostBackupItemWidthStackSize = outer_window->DC.ItemWidthStack.Size;
 		inner_window->DC.PrevLineSize = inner_window->DC.CurrLineSize = ImVec2(0.0f, 0.0f);
+
+		// Make borders not overlap our contents by offsetting HostClipRect (#6765, #7428, #3752)
+		// (we normally shouldn't alter HostClipRect as we rely on TableMergeDrawChannels() expanding non-clipped column toward the
+		// limits of that rectangle, in order for ImDrawListSplitter::Merge() to merge the draw commands. However since the overlap
+		// problem only affect scrolling tables in this case we can get away with doing it without extra cost).
+		if (inner_window != outer_window) {
+			// FIXME: Because inner_window's Scrollbar doesn't know about border size, since it's not encoded in window->WindowBorderSize,
+			// it already overlaps it and doesn't need an extra offset. Ideally we should be able to pass custom border size with
+			// different x/y values to BeginChild().
+			if (flags & ImGuiTableFlags_BordersOuterV) {
+				table->HostClipRect.Min.x = ImMin(table->HostClipRect.Min.x + TABLE_BORDER_SIZE, table->HostClipRect.Max.x);
+				if (inner_window->DecoOuterSizeX2 == 0.0f)
+					table->HostClipRect.Max.x = ImMax(table->HostClipRect.Max.x - TABLE_BORDER_SIZE, table->HostClipRect.Min.x);
+			}
+			if (flags & ImGuiTableFlags_BordersOuterH) {
+				table->HostClipRect.Min.y = ImMin(table->HostClipRect.Min.y + TABLE_BORDER_SIZE, table->HostClipRect.Max.y);
+				if (inner_window->DecoOuterSizeY2 == 0.0f)
+					table->HostClipRect.Max.y = ImMax(table->HostClipRect.Max.y - TABLE_BORDER_SIZE, table->HostClipRect.Min.y);
+			}
+		}
 
 		// Padding and Spacing
 		// - None               ........Content..... Pad .....Content........
@@ -1281,7 +1354,6 @@ namespace ImGuiEx {
 		table->CellSpacingX1 = inner_spacing_explicit + inner_spacing_for_border;
 		table->CellSpacingX2 = inner_spacing_explicit;
 		table->CellPaddingX = inner_padding_explicit;
-		table->CellPaddingY = g.Style.CellPadding.y;
 
 		const float outer_padding_for_border = (flags & ImGuiTableFlags_BordersOuterV) ? TABLE_BORDER_SIZE : 0.0f;
 		const float outer_padding_explicit = pad_outer_x ? g.Style.CellPadding.x : 0.0f;
@@ -1294,71 +1366,88 @@ namespace ImGuiEx {
 		table->InnerClipRect = (inner_window == outer_window) ? table->WorkRect : inner_window->ClipRect;
 		table->InnerClipRect.ClipWith(table->WorkRect); // We need this to honor inner_width
 		table->InnerClipRect.ClipWithFull(table->HostClipRect);
-		table->InnerClipRect.Max.y = (flags & ImGuiTableFlags_NoHostExtendY) ? ImMin(table->InnerClipRect.Max.y, inner_window->WorkRect.Max.y) : inner_window->ClipRect.Max.y;
+		table->InnerClipRect.Max.y = (flags & ImGuiTableFlags_NoHostExtendY) ? ImMin(table->InnerClipRect.Max.y, inner_window->WorkRect.Max.y) : table->HostClipRect.Max.y;
 
 		table->RowPosY1 = table->RowPosY2 = table->WorkRect.Min.y; // This is needed somehow
 		table->RowTextBaseline = 0.0f;                             // This will be cleared again by TableBeginRow()
-		table->FreezeRowsRequest = table->FreezeRowsCount = 0;     // This will be setup by TableSetupScrollFreeze(), if any
+		table->RowCellPaddingY = 0.0f;
+		table->FreezeRowsRequest = table->FreezeRowsCount = 0; // This will be setup by TableSetupScrollFreeze(), if any
 		table->FreezeColumnsRequest = table->FreezeColumnsCount = 0;
 		table->IsUnfrozenRows = true;
-		table->DeclColumnsCount = 0;
+		table->DeclColumnsCount = table->AngledHeadersCount = 0;
+		if (previous_frame_active + 1 < g.FrameCount)
+			table->IsActiveIdInTable = false;
+		table->AngledHeadersHeight = 0.0f;
+		temp_data->AngledHeadersExtraWidth = 0.0f;
 
-		// Using opaque colors facilitate overlapping elements of the grid
-		table->BorderColorStrong = ImGui::GetColorU32(ImGuiCol_TableBorderStrong);
-		table->BorderColorLight = ImGui::GetColorU32(ImGuiCol_TableBorderLight);
+		// Using opaque colors facilitate overlapping lines of the grid, otherwise we'd need to improve TableDrawBorders()
+		table->BorderColorStrong = GetColorU32(ImGuiCol_TableBorderStrong);
+		table->BorderColorLight = GetColorU32(ImGuiCol_TableBorderLight);
 
 		// Make table current
-		const int table_idx = g.Tables.GetIndex(table);
-		g.CurrentTableStack.push_back(ImGuiPtrOrIndex(table_idx));
 		g.CurrentTable = table;
+		inner_window->DC.NavIsScrollPushableX = false; // Shortcut for NavUpdateCurrentWindowIsScrollPushableX();
 		outer_window->DC.CurrentTableIdx = table_idx;
 		if (inner_window != outer_window) // So EndChild() within the inner window can restore the table properly.
 			inner_window->DC.CurrentTableIdx = table_idx;
 
-		if ((table_last_flags & ImGuiTableFlags_Reorderable) && (flags & ImGuiTableFlags_Reorderable) == 0)
+		if ((previous_flags & ImGuiTableFlags_Reorderable) && (flags & ImGuiTableFlags_Reorderable) == 0)
 			table->IsResetDisplayOrderRequest = true;
 
-		// Mark as used
+		// Mark as used to avoid GC
 		if (table_idx >= g.TablesLastTimeActive.Size)
 			g.TablesLastTimeActive.resize(table_idx + 1, -1.0f);
 		g.TablesLastTimeActive[table_idx] = (float) g.Time;
+		temp_data->LastTimeActive = (float) g.Time;
 		table->MemoryCompacted = false;
 
 		// Setup memory buffer (clear data if columns count changed)
-		const int stored_size = table->Columns.size();
-		if (stored_size != 0 && stored_size != columns_count) {
-			IM_FREE(table->RawData);
+		ImGuiTableColumn* old_columns_to_preserve = NULL;
+		void* old_columns_raw_data = NULL;
+		const int old_columns_count = table->Columns.size();
+		if (old_columns_count != 0 && old_columns_count != columns_count) {
+			// Attempt to preserve width and other settings on column count/specs change (#4046)
+			old_columns_to_preserve = table->Columns.Data;
+			old_columns_raw_data = table->RawData; // Free at end of function
 			table->RawData = NULL;
 		}
 		if (table->RawData == NULL) {
-			ImGui::TableBeginInitMemory(table, columns_count);
+			TableBeginInitMemory(table, columns_count);
 			table->IsInitializing = table->IsSettingsRequestLoad = true;
 		}
 		if (table->IsResetAllRequest)
-			ImGui::TableResetSettings(table);
+			TableResetSettings(table);
 		if (table->IsInitializing) {
 			// Initialize
 			table->SettingsOffset = -1;
 			table->IsSortSpecsDirty = true;
+			table->IsSettingsDirty = true; // Records itself into .ini file even when in default state (#7934)
 			table->InstanceInteracted = -1;
 			table->ContextPopupColumn = -1;
-			table->ReorderColumn = table->ResizedColumn = table->LastResizedColumn = -1;
+			table->ReorderColumn = table->ReorderColumnDstOrder = table->ResizedColumn = table->LastResizedColumn = -1;
 			table->AutoFitSingleColumn = -1;
 			table->HoveredColumnBody = table->HoveredColumnBorder = -1;
 			for (int n = 0; n < columns_count; n++) {
 				ImGuiTableColumn* column = &table->Columns[n];
-				float width_auto = column->WidthAuto;
-				*column = ImGuiTableColumn();
-				column->WidthAuto = width_auto;
-				column->IsPreserveWidthAuto = true; // Preserve WidthAuto when reinitializing a live table: not technically necessary but remove a visible flicker
-				column->DisplayOrder = table->DisplayOrderToIndex[n] = (ImGuiTableColumnIdx) n;
-				column->IsEnabled = column->IsEnabledNextFrame = true;
+				if (old_columns_to_preserve && n < old_columns_count) {
+					*column = old_columns_to_preserve[n];
+				} else {
+					float width_auto = column->WidthAuto;
+					*column = ImGuiTableColumn();
+					column->WidthAuto = width_auto;
+					column->IsPreserveWidthAuto = true; // Preserve WidthAuto when reinitializing a live table: not technically necessary but remove a visible flicker
+					column->IsEnabled = column->IsUserEnabled = column->IsUserEnabledNextFrame = true;
+					column->DisplayOrder = (ImGuiTableColumnIdx) n;
+				}
+				table->DisplayOrderToIndex[n] = column->DisplayOrder;
 			}
 		}
+		if (old_columns_raw_data)
+			IM_FREE(old_columns_raw_data);
 
 		// Load settings
 		if (table->IsSettingsRequestLoad)
-			ImGui::TableLoadSettings(table);
+			TableLoadSettings(table);
 
 		// Handle DPI/font resize
 		// This is designed to facilitate DPI changes with the assumption that e.g. style.CellPadding has been scaled as well.
@@ -1368,7 +1457,7 @@ namespace ImGuiEx {
 		const float new_ref_scale_unit = g.FontSize; // g.Font->GetCharAdvance('A') ?
 		if (table->RefScale != 0.0f && table->RefScale != new_ref_scale_unit) {
 			const float scale_factor = new_ref_scale_unit / table->RefScale;
-			//IMGUI_DEBUG_LOG("[table] %08X RefScaleUnit %.3f -> %.3f, scaling width by %.3f\n", table->ID, table->RefScaleUnit, new_ref_scale_unit, scale_factor);
+			//IMGUI_DEBUG_PRINT("[table] %08X RefScaleUnit %.3f -> %.3f, scaling width by %.3f\n", table->ID, table->RefScaleUnit, new_ref_scale_unit, scale_factor);
 			for (int n = 0; n < columns_count; n++)
 				table->Columns[n].WidthRequest = table->Columns[n].WidthRequest * scale_factor;
 		}
@@ -1385,13 +1474,14 @@ namespace ImGuiEx {
 			table->ColumnsNames.Buf.resize(0);
 
 		// Apply queued resizing/reordering/hiding requests
-		ImGui::TableBeginApplyRequests(table);
+		TableBeginApplyRequests(table);
 
 		return true;
 	}
 
 	bool BeginTable(const char* str_id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width, ImGuiWindowFlags child_window_flags) {
 		ImGuiID id = ImGui::GetID(str_id);
+		// This could be ImGui::BeginTable() with g.NextWindowData.WindowFlags set to child_window_flags and g.NextWindowData.HasFlags set to ImGuiNextWindowDataFlags_HasWindowFlags.
 		return BeginTableEx(str_id, id, columns_count, flags, outer_size, inner_width, child_window_flags);
 	}
 

--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -701,7 +701,7 @@ namespace ImGuiEx {
 		if (column.IsEnabled && table->ColumnsEnabledCount <= 1)
 			menu_item_active = false;
 		if (ImGui::MenuItem(columnName, NULL, column.IsEnabled, menu_item_active))
-			column.IsEnabledNextFrame = !column.IsEnabled;
+			column.IsUserEnabledNextFrame = !column.IsEnabled;
 	}
 
 	ImRect TableGetCurrentRowRect() {

--- a/Widgets.h
+++ b/Widgets.h
@@ -337,7 +337,7 @@ namespace ImGuiEx {
 
 			ImGui::PopStyleColor(2);
 
-			if (ImGui::ListBoxHeader("###FilteredCombo_ItemList")) {
+			if (ImGui::BeginListBox("###FilteredCombo_ItemList")) {
 				for (const auto& value : valueCache) {
 					const auto& val = std::get<1>(value);
 					const bool itemSelected = (val == pCurrent);
@@ -349,7 +349,7 @@ namespace ImGuiEx {
 					if (itemSelected)
 						ImGui::SetItemDefaultFocus();
 				}
-				ImGui::ListBoxFooter();
+				ImGui::EndListBox();
 			}
 			ImGui::PopItemWidth();
 			ImGui::EndPopup();
@@ -357,7 +357,7 @@ namespace ImGuiEx {
 
 
 		if (valueChanged)
-			ImGui::MarkItemEdited(g.CurrentWindow->DC.LastItemId);
+			ImGui::MarkItemEdited(g.LastItemData.ID);
 
 		return valueChanged;
 	}

--- a/Windows/MainTable.h
+++ b/Windows/MainTable.h
@@ -275,6 +275,8 @@ namespace ArcdpsExtension {
 
 		bool mCustomColumnsActiveTemp = false; // only here to allow users to have the custom columns feature disabled.
 
+		static constexpr int IMGUI_TABLE_MAX_DRAW_CHANNELS = 4 + 64 * 2;
+
 		// Utilities to control ImGui, use these instead of ImGui directly!
 	protected:
 		/**
@@ -639,7 +641,7 @@ namespace ArcdpsExtension {
 
 		static ImGuiSortDirection GetColumnAvailSortDirection(TableColumn* column, int n) {
 			IM_ASSERT(n < column->SortDirectionsAvailCount);
-			return (column->SortDirectionsAvailList >> (n << 1)) & 0x03;
+			return (ImGuiSortDirection)((column->SortDirectionsAvailList >> (n << 1)) & 0x03);
 		}
 
 		void EndCell();
@@ -773,7 +775,7 @@ namespace ArcdpsExtension {
 
 			for (const auto& column : mColumns) {
 				if (NextColumn()) {
-					ColumnHeader(column.Name(), false, column.Texture(), getHeaderAlignment(), column.Popup());
+					ColumnHeader(column.Name(), false, (ImTextureID)column.Texture(), getHeaderAlignment(), column.Popup());
 				}
 			}
 
@@ -975,9 +977,9 @@ namespace ArcdpsExtension {
 	void MainTable<MaxColumnCount>::BeginInitMemory(int columns_count) {
 		// Allocate single buffer for our arrays
 		ImSpanAllocator<3> span_allocator;
-		span_allocator.ReserveBytes(0, columns_count * sizeof(TableColumn));
-		span_allocator.ReserveBytes(1, columns_count * sizeof(TableColumnIdx));
-		span_allocator.ReserveBytes(2, columns_count * sizeof(ImGuiTableCellData));
+		span_allocator.Reserve(0, columns_count * sizeof(TableColumn));
+		span_allocator.Reserve(1, columns_count * sizeof(TableColumnIdx));
+		span_allocator.Reserve(2, columns_count * sizeof(ImGuiTableCellData));
 		mTable.RawData = IM_ALLOC(span_allocator.GetArenaSizeInBytes());
 		memset(mTable.RawData, 0, span_allocator.GetArenaSizeInBytes());
 		span_allocator.SetArenaBasePtr(mTable.RawData);
@@ -1307,7 +1309,7 @@ namespace ArcdpsExtension {
 			// Allocate width for stretched/weighted columns (StretchWeight gets converted into WidthRequest)
 			if (column->Flags & ImGuiTableColumnFlags_WidthStretch) {
 				float weight_ratio = column->StretchWeight / stretch_sum_weights;
-				column->WidthRequest = IM_FLOOR(ImMax(width_avail_for_stretched_columns * weight_ratio, mTable.MinColumnWidth) + 0.01f);
+				column->WidthRequest = IM_TRUNC(ImMax(width_avail_for_stretched_columns * weight_ratio, mTable.MinColumnWidth) + 0.01f);
 				width_remaining_for_stretched_columns -= column->WidthRequest;
 			}
 
@@ -1338,7 +1340,7 @@ namespace ArcdpsExtension {
 		mTable.HoveredColumnBody = -1;
 		mTable.HoveredColumnBorder = -1;
 		const ImRect mouse_hit_rect(mTable.OuterRect.Min.x, mTable.OuterRect.Min.y, mTable.OuterRect.Max.x, ImMax(mTable.OuterRect.Max.y, mTable.OuterRect.Min.y + mTable.LastOuterHeight));
-		const bool is_hovering_table = ImGui::ItemHoverable(mouse_hit_rect, 0);
+		const bool is_hovering_table = ImGui::ItemHoverable(mouse_hit_rect, 0, ImGuiItemFlags_None);
 
 		// [Part 6] Setup final position, offset, skip/clip states and clipping rectangles, detect hovered column
 		// Process columns in their visible orders as we are comparing the visible order and adjusting host_clip_rect while looping.
@@ -1544,7 +1546,7 @@ namespace ArcdpsExtension {
 			sort_spec->ColumnUserID = column->UserID;
 			sort_spec->ColumnIndex = (TableColumnIdx) column_n;
 			sort_spec->SortOrder = (TableColumnIdx) column->SortOrder;
-			sort_spec->SortDirection = column->SortDirection;
+			sort_spec->SortDirection = (ImGuiSortDirection) column->SortDirection;
 		}
 		mTable.SortSpecs.Specs = sort_specs;
 		mTable.SortSpecs.SpecsCount = mTable.SortSpecsCount;
@@ -1949,8 +1951,8 @@ namespace ArcdpsExtension {
 						merge_clip_rect.Max.y = ImMax(merge_clip_rect.Max.y, host_rect.Max.y);
 
 					remaining_count -= merge_group->ChannelsCount;
-					for (int n = 0; n < IM_ARRAYSIZE(remaining_mask.Storage); n++)
-						remaining_mask.Storage[n] &= ~merge_group->ChannelsMask.Storage[n];
+					for (int n = 0; n < IM_ARRAYSIZE(remaining_mask.Data); n++)
+						remaining_mask.Data[n] &= ~merge_group->ChannelsMask.Data[n];
 					for (int n = 0; n < splitter->_Count && merge_channels_count != 0; n++) {
 						// Copy + overwrite new clip rect
 						if (!merge_group->ChannelsMask.TestBit(n))
@@ -2271,7 +2273,7 @@ namespace ArcdpsExtension {
 			ImGui::KeepAliveID(column_id);
 
 			bool hovered = false, held = false;
-			bool pressed = ImGui::ButtonBehavior(hit_rect, column_id, &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+			bool pressed = ImGui::ButtonBehavior(hit_rect, column_id, &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowOverlap | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
 			if (pressed && ImGui::IsMouseDoubleClicked(0)) {
 				SetColumnWidthAutoSingle(column_n);
 				ImGui::ClearActiveID();
@@ -2388,6 +2390,7 @@ namespace ArcdpsExtension {
 	template<size_t MaxColumnCount>
 	requires SmallerThanMaxColumnAmount<MaxColumnCount>
 	void MainTable<MaxColumnCount>::BeginCell(int column_n) {
+		ImGuiContext& g = *GImGui;
 		TableColumn* column = &mTable.Columns[column_n];
 		ImGuiWindow* window = mTable.InnerWindow;
 		mTable.CurrentColumn = column_n;
@@ -2415,8 +2418,8 @@ namespace ArcdpsExtension {
 
 		window->SkipItems = column->IsSkipItems;
 		if (column->IsSkipItems) {
-			window->DC.LastItemId = 0;
-			window->DC.LastItemStatusFlags = 0;
+			g.LastItemData.ID = 0;
+			g.LastItemData.StatusFlags = 0;
 		}
 
 		if (mTable.Flags & ImGuiTableFlags_NoClip) {
@@ -2698,7 +2701,7 @@ namespace ArcdpsExtension {
 		ImVec2 actual_outer_size = ImGui::CalcItemSize(outer_size, ImMax(avail_size.x, 1.0f), use_child_window ? ImMax(avail_size.y, 1.0f) : 0.0f);
 		ImRect outer_rect(outer_window->DC.CursorPos, outer_window->DC.CursorPos + actual_outer_size);
 
-		if (use_child_window && ImGui::IsClippedEx(outer_rect, 0, false)) {
+		if (use_child_window && ImGui::IsClippedEx(outer_rect, 0)) {
 			ImGui::ItemSize(outer_rect);
 			// This causes issues with the killproof.me plugin.
 			// Removing this return will fix those, if you find issues with the removal of this return tell me.
@@ -3288,15 +3291,15 @@ namespace ArcdpsExtension {
 
 		// Using AllowItemOverlap mode because we cover the whole cell, and we want user to be able to submit subsequent items.
 		bool hovered, held;
-		bool pressed = ImGui::ButtonBehavior(bb, id, &hovered, &held, ImGuiButtonFlags_AllowItemOverlap);
-		if (g.ActiveId != id)
-			ImGui::SetItemAllowOverlap();
+		bool pressed = ImGui::ButtonBehavior(bb, id, &hovered, &held, ImGuiButtonFlags_AllowOverlap);
+		// if (g.ActiveId != id)
+		//	ImGui::SetItemAllowOverlap();
 		if (held || hovered || selected) {
 			const ImU32 col = ImGui::GetColorU32(held ? ImGuiCol_HeaderActive : hovered ? ImGuiCol_HeaderHovered
 																						: ImGuiCol_Header);
 			//RenderFrame(bb.Min, bb.Max, col, false, 0.0f);
 			SetBgColor(ImGuiTableBgTarget_CellBg, col, mTable.CurrentColumn);
-			ImGui::RenderNavHighlight(bb, id, ImGuiNavHighlightFlags_TypeThin | ImGuiNavHighlightFlags_NoRounding);
+			ImGui::RenderNavHighlight(bb, id, ImGuiNavRenderCursorFlags_Compact | ImGuiNavHighlightFlags_NoRounding);
 		} else {
 			// Submit single cell bg color in the case we didn't submit a full header row
 			if ((mTable.RowFlags & ImGuiTableRowFlags_Headers) == 0)
@@ -3372,7 +3375,7 @@ namespace ArcdpsExtension {
 				case Alignment::Unaligned: break;
 			}
 
-			ImGui::RenderTextEllipsis(window->DrawList, ImVec2(newX, label_pos.y), ImVec2(ellipsis_max, label_pos.y + label_height + g.Style.FramePadding.y), ellipsis_max, ellipsis_max, label.data(), label.data() + label.size(), &label_size);
+			ImGui::RenderTextEllipsis(window->DrawList, ImVec2(newX, label_pos.y), ImVec2(ellipsis_max, label_pos.y + label_height + g.Style.FramePadding.y), ellipsis_max, label.data(), label.data() + label.size(), &label_size);
 		} else {
 			float newX = label_pos.x;
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -89,7 +89,7 @@ void ArcdpsExtension::MainWindow::Draw(ImGuiWindowFlags imGuiWindowFlags, MainWi
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(4, 4));
 	if (ImGuiEx::BeginPopupContextWindow(nullptr, 1, ImGuiHoveredFlags_ChildWindows)) {
 		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-		ImGui::PushItemFlag(ImGuiItemFlags_SelectableDontClosePopup, true);
+		ImGui::PushItemFlag(ImGuiItemFlags_AutoClosePopups, true);
 
 		DrawContextMenu();
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
     {
 	  "kind": "git",
 	  "repository": "https://github.com/Zinn-o-Matics/vcpkg-registry",
-	  "baseline": "7448b5e8664a18302146c6e29e0ff0cafe37664e",
+	  "baseline": "8e1ef88d2a5ace53cded43ea0729f6a8cc369c8e",
 	  "packages": [ "imgui", "arcdps-unofficial-extras" ]
 	}
   ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -42,7 +42,7 @@
   "overrides": [
     {
       "name": "imgui",
-      "version": "1.80#1"
+      "version": "1.92.7"
     }
   ]
 }


### PR DESCRIPTION
Upgrade ImGui to 1.92.7

- Use ImGui namespace in Widgets.cpp to avoid having to add `ImGui::` everywhere
- `BeginTableEx` might not be needed anymore as the new implementation reads child flags from `g.NextWindowData.WindowFlags` if `g.NextWindowData.HasFlags` has `ImGuiNextWindowDataFlags_HasWindowFlags` , but that should be tested.