### PR TITLE
Update BeginPopupContextWindow() to handle the new ImGuiPopupFlags_ values

### DIFF
--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -683,7 +683,7 @@ namespace ImGuiEx {
 		if (!str_id)
 			str_id = "window_context";
 		ImGuiID id = window->GetID(str_id);
-		int mouse_button = (popup_flags & ImGuiPopupFlags_MouseButtonMask_);
+		ImGuiMouseButton mouse_button = GetMouseButtonFromPopupFlags(popup_flags);
 		hovered_flags |= ImGuiHoveredFlags_AllowWhenBlockedByPopup;
 		if (ImGui::IsMouseReleased(mouse_button) && ImGui::IsWindowHovered(hovered_flags))
 			if (!(popup_flags & ImGuiPopupFlags_NoOpenOverItems) || !ImGui::IsAnyItemHovered())

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -87,7 +87,7 @@ void ArcdpsExtension::MainWindow::Draw(ImGuiWindowFlags imGuiWindowFlags, MainWi
 	mThisWindow = ImGui::GetCurrentWindow();
 
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(4, 4));
-	if (ImGuiEx::BeginPopupContextWindow(nullptr, 1, ImGuiHoveredFlags_ChildWindows)) {
+	if (ImGuiEx::BeginPopupContextWindow(nullptr, ImGuiPopupFlags_MouseButtonRight, ImGuiHoveredFlags_ChildWindows)) {
 		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
 		ImGui::PushItemFlag(ImGuiItemFlags_AutoClosePopups, true);
 


### PR DESCRIPTION
Update BeginPopupContextWindow() to handle the new ImGuiPopupFlags_ values. The values changed to masks

>// - IMPORTANT: If you ever used the left mouse button with BeginPopupContextXXX() helpers before 1.92.6: Read "API BREAKING CHANGES" 2026/01/07 (1.92.6) entry in imgui.cpp or GitHub topic #9157.
// - Multiple buttons currently cannot be combined/or-ed in those functions (we could allow it later).