### PR TITLE
Fix progress bar text alignment since ImGui 1.92.7 upgrade

### DIFF
--- a/Widgets.cpp
+++ b/Widgets.cpp
@@ -373,6 +373,9 @@ namespace ImGuiEx {
 			ImVec2 overlay_size = CalcTextSize(overlay, NULL);
 			if (overlay_size.x > 0.0f) {
 				ImVec2 alignRender = ImVec2(0.0f, 0.5f);
+				// By default consider the whole cell for text placement and alignment
+				float text_x = is_indeterminate ? (bb.Min.x + bb.Max.x - overlay_size.x) * 0.5f : bb.Min.x;
+
 				switch (alignment) {
 					case Alignment::Left:
 						alignRender = ImVec2(0.f, 0.f);
@@ -383,9 +386,12 @@ namespace ImGuiEx {
 					case Alignment::Right:
 						alignRender = ImVec2(1.f, 0.f);
 						break;
+					default:
+						// Fallback to default ImGui alignment which is left aligned after the progress bar fill
+						text_x = is_indeterminate ? (bb.Min.x + bb.Max.x - overlay_size.x) * 0.5f : fill_x1 + style.ItemSpacing.x;
+						break;
 				}
 
-				float text_x = is_indeterminate ? (bb.Min.x + bb.Max.x - overlay_size.x) * 0.5f : fill_x1 + style.ItemSpacing.x;
 				RenderTextClipped(
 						ImVec2(ImClamp(text_x, bb.Min.x, bb.Max.x - overlay_size.x - style.ItemInnerSpacing.x), bb.Min.y), bb.Max,
 						overlay, NULL, &overlay_size, alignRender, &bb


### PR DESCRIPTION
Fix progress bar text alignment since ImGui 1.92.7 upgrade

Left:
<img width="549" height="87" alt="image" src="https://github.com/user-attachments/assets/dbdb0493-c473-426e-b574-077bfbc7d782" />

Centered:
<img width="545" height="80" alt="image" src="https://github.com/user-attachments/assets/8709d023-5324-43c5-8319-5736428081b7" />

Right:
<img width="547" height="85" alt="image" src="https://github.com/user-attachments/assets/ffd4defb-e3cc-4269-9be0-7860162d1b7a" />

Standard (after fill bar):
<img width="541" height="83" alt="image" src="https://github.com/user-attachments/assets/aa312e25-3cda-4a15-914b-a2961d809977" />

