### PR TITLE
Add support for Traditional Chinese (TChinese) localization

### DIFF
--- a/ExtensionTranslations.h
+++ b/ExtensionTranslations.h
@@ -257,6 +257,57 @@ constexpr auto EXTENSION_TRANSLATION_SPANISH = std::to_array({
 	u8"Mostrar la cabecera con texto en lugar de imágenes", // ET_SettingsShowHeaderText
  });
 
+constexpr auto EXTENSION_TRANSLATION_CHINESE = std::to_array({
+	u8"靠左",	            // ET_Left,
+	u8"靠右",	        //     ET_Right,
+	u8"置中",	        //     ET_Center,
+	u8"標準",	        //     ET_Unaligned,
+	u8"手動",	        //     ET_PositionManual,
+	u8"螢幕相對位置",	//     ET_PositionScreenRelative,
+	u8"視窗相對位置",	// 	ET_PositionWindowRelative,
+	u8"未知",	        //     ET_Unknown,
+	u8"左上",	        //     ET_CornerPositionTopLeft,
+	u8"右上",        //     ET_CornerPositionTopRight,
+	u8"左下",	    //     ET_CornerPositionBottomLeft,
+	u8"右下",	    //     ET_CornerPositionBottomRight,
+	u8"根據內容自動調整視窗大小",	//     ET_SizingPolicySizeToContent,
+	u8"調整內容到視窗的大小",	//     ET_SizingPolicySizeContentToWindow,
+	u8"手動調整視窗大小",	//     ET_SizingPolicyManualWindowSize,
+	u8"按鍵綁定",	        //     ET_KeyInputPopupName,
+	u8"確定",	        //     ET_ApplyButton,
+	u8"取消",	        //     ET_CancelButton,
+	u8"{} 有新的更新可用。",	//     ET_UpdateDesc,
+	u8"當前版本",	//     ET_UpdateCurrentVersion,
+	u8"新版本",	    //     ET_UpdateNewVersion,
+	u8"打開下載頁面",	//     ET_UpdateOpenPage,
+	u8"自動更新",	//     ET_UpdateAutoButton,
+	u8"自動更新正在進行中s",	//     ET_UpdateInProgress,
+	u8"自動更新已完成，重新啟動遊戲即可啟動。",	//     ET_UpdateRestartPending,
+	u8"自動更新失敗，請手動更新。",	//     ET_UpdateError,
+	u8"樣式", // ET_Style
+	u8"標題列", // ET_TitleBar
+	u8"背景", // ET_Background
+	u8"滾動條", // ET_Scrollbar
+	u8"邊距", // ET_Padding
+	u8"大小調整策略", // ET_SizingPolicy
+	u8"顯示在選項中的文字", // ET_AppearAsInOption
+	u8"標題列文字", // ET_TitleBarText
+	u8"快捷鍵", // ET_Shortcut
+	u8"位置", // ET_Position
+	u8"從錨點面板角落", // ET_FromAnchorPanelCorner
+	u8"到此面板角落", // ET_ThisPanelCorner
+	u8"錨點視窗", // ET_AnchorWindow
+	u8"欄位設置", // ET_ColumnSetup
+	u8"根據地圖顯示欄位", // ET_ShowBasedOnMap
+	u8"交替表列背景", // ET_AlternatingRowBg
+	u8"突出顯示被懸停的表行", // ET_HighlightHoveredRow
+	u8"最大顯示數量", // ET_MaxDisplayed
+	u8"表頭對齊", // ET_HeaderAlignment
+	u8"表列對齊", // ET_ColumnAlignment
+	u8"語言", // ET_Language
+	u8"標題以文字替代圖標顯示", // ET_SettingsShowHeaderText
+});
+
 #if __has_include("magic_enum.hpp")
 #include <magic_enum.hpp>
 static_assert(EXTENSION_TRANSLATION_ENGLISH.size() == magic_enum::enum_count<ExtensionTranslation>());
@@ -264,3 +315,4 @@ static_assert(EXTENSION_TRANSLATION_ENGLISH.size() == magic_enum::enum_count<Ext
 static_assert(EXTENSION_TRANSLATION_ENGLISH.size() == EXTENSION_TRANSLATION_GERMAN.size());
 static_assert(EXTENSION_TRANSLATION_ENGLISH.size() == EXTENSION_TRANSLATION_FRENCH.size());
 static_assert(EXTENSION_TRANSLATION_ENGLISH.size() == EXTENSION_TRANSLATION_SPANISH.size());
+static_assert(EXTENSION_TRANSLATION_ENGLISH.size() == EXTENSION_TRANSLATION_CHINESE.size());

--- a/ExtensionTranslations.h
+++ b/ExtensionTranslations.h
@@ -323,6 +323,59 @@ namespace ArcdpsExtension {
 			u8"简体中文",                 // ET_LanguageName
 			u8"与游戏一致",               // ET_LikeInGame
 	});
+
+	constexpr auto EXTENSION_TRANSLATION_TCHINESE = std::to_array({
+			u8"靠左", // ET_Left,
+			u8"靠右", // ET_Right,
+			u8"置中", // ET_Center,
+			u8"標準", // ET_Unaligned,
+			u8"手動", // ET_PositionManual,
+			u8"螢幕相對位置", // ET_PositionScreenRelative,
+			u8"視窗相對位置", // ET_PositionWindowRelative,
+			u8"未知", // ET_Unknown,
+			u8"左上", // ET_CornerPositionTopLeft,
+			u8"右上", // ET_CornerPositionTopRight,
+			u8"左下", // ET_CornerPositionBottomLeft,
+			u8"右下", // ET_CornerPositionBottomRight,
+			u8"根據內容自動調整視窗大小", // ET_SizingPolicySizeToContent,
+			u8"調整內容到視窗的大小", // ET_SizingPolicySizeContentToWindow,
+			u8"手動調整視窗大小", // ET_SizingPolicyManualWindowSize,
+			u8"按鍵綁定", // ET_KeyInputPopupName,
+			u8"確定", // ET_ApplyButton,
+			u8"取消", // ET_CancelButton,
+			u8"{} 有新的更新可用。", // ET_UpdateDesc,
+			u8"當前版本", // ET_UpdateCurrentVersion,
+			u8"新版本", // ET_UpdateNewVersion,
+			u8"打開下載頁面", // ET_UpdateOpenPage,
+			u8"自動更新", // ET_UpdateAutoButton,
+			u8"自動更新正在進行中", // ET_UpdateInProgress,
+			u8"自動更新已完成，重新啟動遊戲即可啟動。",	// ET_UpdateRestartPending,
+			u8"自動更新失敗，請手動更新。",	// ET_UpdateError,
+			u8"樣式", // ET_Style
+			u8"標題列", // ET_TitleBar
+			u8"背景", // ET_Background
+			u8"滾動條", // ET_Scrollbar
+			u8"邊距", // ET_Padding
+			u8"大小調整策略", // ET_SizingPolicy
+			u8"顯示在選項中的文字", // ET_AppearAsInOption
+			u8"標題列文字", // ET_TitleBarText
+			u8"快捷鍵", // ET_Shortcut
+			u8"位置", // ET_Position
+			u8"從錨點面板角落", // ET_FromAnchorPanelCorner
+			u8"到此面板角落", // ET_ThisPanelCorner
+			u8"錨點視窗", // ET_AnchorWindow
+			u8"欄位設置", // ET_ColumnSetup
+			u8"根據地圖顯示欄位", // ET_ShowBasedOnMap
+			u8"交替表列背景", // ET_AlternatingRowBg
+			u8"突出顯示被懸停的表行", // ET_HighlightHoveredRow
+			u8"最大顯示數量", // ET_MaxDisplayed
+			u8"表頭對齊", // ET_HeaderAlignment
+			u8"表列對齊", // ET_ColumnAlignment
+			u8"語言", // ET_Language
+			u8"標題以文字替代圖標顯示", // ET_SettingsShowHeaderText
+			u8"繁體中文", // ET_LanguageName
+			u8"與遊戲一致", // ET_LikeInGame
+		});
 } // namespace ArcdpsExtension
 
 static_assert(ArcdpsExtension::EXTENSION_TRANSLATION_ENGLISH.size() == magic_enum::enum_count<ArcdpsExtension::ExtensionTranslation>());
@@ -330,3 +383,4 @@ static_assert(ArcdpsExtension::EXTENSION_TRANSLATION_ENGLISH.size() == ArcdpsExt
 static_assert(ArcdpsExtension::EXTENSION_TRANSLATION_ENGLISH.size() == ArcdpsExtension::EXTENSION_TRANSLATION_FRENCH.size());
 static_assert(ArcdpsExtension::EXTENSION_TRANSLATION_ENGLISH.size() == ArcdpsExtension::EXTENSION_TRANSLATION_SPANISH.size());
 static_assert(ArcdpsExtension::EXTENSION_TRANSLATION_ENGLISH.size() == ArcdpsExtension::EXTENSION_TRANSLATION_CHINESE.size());
+static_assert(ArcdpsExtension::EXTENSION_TRANSLATION_ENGLISH.size() == ArcdpsExtension::EXTENSION_TRANSLATION_TCHINESE.size());

--- a/ExtensionTranslations.h
+++ b/ExtensionTranslations.h
@@ -324,57 +324,57 @@ namespace ArcdpsExtension {
 			{ET_LikeInGame,                      u8"与游戏一致"              },
 	});
 
-	constexpr auto EXTENSION_TRANSLATION_TCHINESE = std::to_array({
-			u8"靠左", // ET_Left,
-			u8"靠右", // ET_Right,
-			u8"置中", // ET_Center,
-			u8"標準", // ET_Unaligned,
-			u8"手動", // ET_PositionManual,
-			u8"螢幕相對位置", // ET_PositionScreenRelative,
-			u8"視窗相對位置", // ET_PositionWindowRelative,
-			u8"未知", // ET_Unknown,
-			u8"左上", // ET_CornerPositionTopLeft,
-			u8"右上", // ET_CornerPositionTopRight,
-			u8"左下", // ET_CornerPositionBottomLeft,
-			u8"右下", // ET_CornerPositionBottomRight,
-			u8"根據內容自動調整視窗大小", // ET_SizingPolicySizeToContent,
-			u8"調整內容到視窗的大小", // ET_SizingPolicySizeContentToWindow,
-			u8"手動調整視窗大小", // ET_SizingPolicyManualWindowSize,
-			u8"按鍵綁定", // ET_KeyInputPopupName,
-			u8"確定", // ET_ApplyButton,
-			u8"取消", // ET_CancelButton,
-			u8"{} 有新的更新可用。", // ET_UpdateDesc,
-			u8"當前版本", // ET_UpdateCurrentVersion,
-			u8"新版本", // ET_UpdateNewVersion,
-			u8"打開下載頁面", // ET_UpdateOpenPage,
-			u8"自動更新", // ET_UpdateAutoButton,
-			u8"自動更新正在進行中", // ET_UpdateInProgress,
-			u8"自動更新已完成，重新啟動遊戲即可啟動。",	// ET_UpdateRestartPending,
-			u8"自動更新失敗，請手動更新。",	// ET_UpdateError,
-			u8"樣式", // ET_Style
-			u8"標題列", // ET_TitleBar
-			u8"背景", // ET_Background
-			u8"滾動條", // ET_Scrollbar
-			u8"邊距", // ET_Padding
-			u8"大小調整策略", // ET_SizingPolicy
-			u8"顯示在選項中的文字", // ET_AppearAsInOption
-			u8"標題列文字", // ET_TitleBarText
-			u8"快捷鍵", // ET_Shortcut
-			u8"位置", // ET_Position
-			u8"從錨點面板角落", // ET_FromAnchorPanelCorner
-			u8"到此面板角落", // ET_ThisPanelCorner
-			u8"錨點視窗", // ET_AnchorWindow
-			u8"欄位設置", // ET_ColumnSetup
-			u8"根據地圖顯示欄位", // ET_ShowBasedOnMap
-			u8"交替表列背景", // ET_AlternatingRowBg
-			u8"突出顯示被懸停的表行", // ET_HighlightHoveredRow
-			u8"最大顯示數量", // ET_MaxDisplayed
-			u8"表頭對齊", // ET_HeaderAlignment
-			u8"表列對齊", // ET_ColumnAlignment
-			u8"語言", // ET_Language
-			u8"標題以文字替代圖標顯示", // ET_SettingsShowHeaderText
-			u8"繁體中文", // ET_LanguageName
-			u8"與遊戲一致", // ET_LikeInGame
+	constexpr auto EXTENSION_TRANSLATION_TCHINESE = std::to_array<std::pair<ExtensionTranslation, const char8_t*>>({
+			{ET_Left,							u8"靠左"                    },
+			{ET_Right,						   u8"靠右"                    },
+			{ET_Center,						  u8"置中"                    },
+			{ET_Unaligned,                       u8"標準"                  },
+			{ET_PositionManual,                  u8"手動"                },
+			{ET_PositionScreenRelative,          u8"螢幕相對位置"            },
+			{ET_PositionWindowRelative,          u8"視窗相對位置"            },
+			{ET_Unknown,						 u8"未知"                    },
+			{ET_CornerPositionTopLeft,           u8"左上"                  },
+			{ET_CornerPositionTopRight,          u8"右上"                  },
+			{ET_CornerPositionBottomLeft,        u8"左下"                  },
+			{ET_CornerPositionBottomRight,       u8"右下"                  },
+			{ET_SizingPolicySizeToContent,       u8"根據內容自動調整視窗大小"},
+			{ET_SizingPolicySizeContentToWindow, u8"調整內容到視窗的大小"},
+			{ET_SizingPolicyManualWindowSize,    u8"手動調整視窗大小"        },
+			{ET_KeyInputPopupName,               u8"按鍵綁定"                  },
+			{ET_ApplyButton,                     u8"確定"                    },
+			{ET_CancelButton,                    u8"取消"                    },
+			{ET_UpdateDesc,                      u8"{} 有新的更新可用。"     },
+			{ET_UpdateCurrentVersion,            u8"當前版本"                  },
+			{ET_UpdateNewVersion,                u8"新版本"                  },
+			{ET_UpdateOpenPage,                  u8"打開下載頁面"            },
+			{ET_UpdateAutoButton,                u8"自動更新"                },
+			{ET_UpdateInProgress,                u8"自動更新正在進行中"        },
+			{ET_UpdateRestartPending,            u8"自動更新已完成，重新啟動遊戲即可啟動。"},
+			{ET_UpdateError,                     u8"自動更新失敗，請手動更新。"},
+			{ET_Style,						   u8"樣式"                },
+			{ET_TitleBar,                        u8"標題列"          },
+			{ET_Background,                      u8"背景"                },
+			{ET_Scrollbar,                       u8"滾動條"                  },
+			{ET_Padding,						 u8"邊距"                    },
+			{ET_SizingPolicy,                    u8"大小調整策略"                },
+			{ET_AppearAsInOption,                u8"顯示在選項中的文字"            },
+			{ET_TitleBarText,                    u8"標題列文字"          },
+			{ET_Shortcut,                        u8"快捷鍵"                  },
+			{ET_Position,                        u8"位置"                    },
+			{ET_FromAnchorPanelCorner,           u8"從錨點面板角落"            },
+			{ET_ThisPanelCorner,                 u8"到此面板角落"            },
+			{ET_AnchorWindow,                    u8"錨點視窗"                },
+			{ET_ColumnSetup,                     u8"欄位設置"                  },
+			{ET_UseCustomColumns,                u8"使用自訂欄位"        },
+			{ET_AlternatingRowBg,                u8"交替表列背景"          },
+			{ET_HighlightHoveredRow,             u8"突出顯示被懸停的表行"    },
+			{ET_MaxDisplayed,                    u8"最大顯示數量"            },
+			{ET_HeaderAlignment,                 u8"表頭對齊"            },
+			{ET_ColumnAlignment,                 u8"表列對齊"              },
+			{ET_Language,                        u8"語言"                    },
+			{ET_SettingsShowHeaderText,          u8"標題以文字替代圖標顯示"    },
+			{ET_LanguageName,                    u8"繁體中文"                },
+			{ET_LikeInGame,                      u8"與遊戲一致"              },
 		});
 } // namespace ArcdpsExtension
 

--- a/Localization.cpp
+++ b/Localization.cpp
@@ -9,6 +9,7 @@ Localization::Localization() {
     Load(GWL_GEM, EXTENSION_TRANSLATION_GERMAN);
     Load(GWL_SPA, EXTENSION_TRANSLATION_SPANISH);
     Load(GWL_FRE, EXTENSION_TRANSLATION_FRENCH);
+	Load(GWL_CN, EXTENSION_TRANSLATION_CHINESE);
 }
 
 const std::string &Localization::Translate(size_t pId) const {

--- a/Localization.cpp
+++ b/Localization.cpp
@@ -8,6 +8,7 @@ ArcdpsExtension::Localization::Localization() {
 	Load(Lang::Spanish, EXTENSION_TRANSLATION_SPANISH);
 	Load(Lang::French, EXTENSION_TRANSLATION_FRENCH);
 	Load(Lang::Chinese, EXTENSION_TRANSLATION_CHINESE);
+	Load(Lang::TChinese, EXTENSION_TRANSLATION_TCHINESE);
 
 	mCurrentTranslation = &mTranslations.at(Lang::English);
 	mFallbackTranslation = &mTranslations.at(Lang::English);
@@ -51,6 +52,8 @@ const std::string& ArcdpsExtension::Localization::ToLangCode(gwlanguage lang) {
 			return Lang::Spanish;
 		case GWL_CN:
 			return Lang::Chinese;
+		case GWL_TW:
+			return Lang::TChinese;
 		default:
 			return Lang::English;
 	}

--- a/Localization.cpp
+++ b/Localization.cpp
@@ -10,6 +10,7 @@ ArcdpsExtension::Localization::Localization() {
 	Load(GWL_SPA, EXTENSION_TRANSLATION_SPANISH);
 	Load(GWL_FRE, EXTENSION_TRANSLATION_FRENCH);
 	Load(GWL_CN, EXTENSION_TRANSLATION_CHINESE);
+	Load(GWL_TW, EXTENSION_TRANSLATION_TCHINESE);
 }
 
 std::string_view ArcdpsExtension::Localization::Translate(size_t pId) const {
@@ -39,6 +40,8 @@ std::string_view to_string(ArcdpsExtension::LanguageSetting pLang) {
 			return ArcdpsExtension::Localization::STranslate(ArcdpsExtension::LanguageSetting::Spanish, ArcdpsExtension::ET_LanguageName);
 		case ArcdpsExtension::LanguageSetting::Chinese:
 			return ArcdpsExtension::Localization::STranslate(ArcdpsExtension::LanguageSetting::Chinese, ArcdpsExtension::ET_LanguageName);
+		case ArcdpsExtension::LanguageSetting::TChinese:
+			return ArcdpsExtension::Localization::STranslate(ArcdpsExtension::LanguageSetting::TChinese, ArcdpsExtension::ET_LanguageName);
 		default:
 			return "Error, if you see this, please report it to the developer";
 	}

--- a/Localization.h
+++ b/Localization.h
@@ -101,7 +101,7 @@ namespace ArcdpsExtension {
 		}
 
 	private:
-		std::array<std::vector<std::string>, 6> mTranslations;
+		std::array<std::vector<std::string>, 7> mTranslations;
 		gwlanguage mCurrentLanguage = GWL_ENG;
 		std::vector<std::string>* mCurrentTranslation;
 	};

--- a/Localization.h
+++ b/Localization.h
@@ -28,6 +28,7 @@ namespace ArcdpsExtension {
 		inline std::string German = "de";
 		inline std::string Spanish = "es";
 		inline std::string Chinese = "zh-cn";
+		inline std::string TChinese = "zh-tw";
 	} // namespace Lang
 
 	namespace details {

--- a/Localization.h
+++ b/Localization.h
@@ -115,6 +115,7 @@ namespace ArcdpsExtension {
 		German = 3,
 		Spanish = 4,
 		Chinese = 5,
+		TChinese = 6,
 	};
 } // namespace ArcdpsExtension
 

--- a/LocalizationTests.cpp
+++ b/LocalizationTests.cpp
@@ -19,6 +19,8 @@ TEST(LocalizationTests, BaseTranslations) {
 	ASSERT_EQ(localization.Translate(ET_Left), "Izquierda");
 	localization.ChangeLanguage(Lang::Chinese);
 	ASSERT_EQ(localization.Translate(ET_Left), "居左");
+	localization.ChangeLanguage(Lang::TChinese);
+	ASSERT_EQ(localization.Translate(ET_Left), "靠左");
 }
 
 TEST(LocalizationTests, BaseTranslationsLang) {
@@ -29,6 +31,7 @@ TEST(LocalizationTests, BaseTranslationsLang) {
 	ASSERT_EQ(localization.Translate(Lang::French, ET_Left), "Gauche");
 	ASSERT_EQ(localization.Translate(Lang::Spanish, ET_Left), "Izquierda");
 	ASSERT_EQ(localization.Translate(Lang::Chinese, ET_Left), "居左");
+	ASSERT_EQ(localization.Translate(Lang::TChinese, ET_Left), "靠左");
 }
 
 TEST(LocalizationTests, BaseTranslationsSpecialChars) {
@@ -42,6 +45,8 @@ TEST(LocalizationTests, BaseTranslationsSpecialChars) {
 	ASSERT_EQ(localization.Translate(ET_UpdateInProgress), "Actualización automática en curso");
 	localization.ChangeLanguage(Lang::Chinese);
 	ASSERT_EQ(localization.Translate(ET_SizingPolicySizeContentToWindow), "根据窗口大小调整内容大小");
+	localization.ChangeLanguage(Lang::TChinese);
+	ASSERT_EQ(localization.Translate(ET_SizingPolicySizeContentToWindow), "調整內容到視窗的大小");
 }
 
 TEST(LocalizationTests, OverrideTranslation) {

--- a/arcdps_structs_slim.h
+++ b/arcdps_structs_slim.h
@@ -630,6 +630,7 @@ enum gwlanguage {
 	GWL_GEM = 3,
 	GWL_SPA = 4,
 	GWL_CN = 5,
+	GWL_TW = 6,
 };
 
 /* content local enum */


### PR DESCRIPTION
## Description
This PR adds support for Traditional Chinese (TChinese) localization. 

## Motivation
I am currently updating the **ArcDPS Boon Table** project (`ArcDPS Boon Table.sln`) to support Traditional Chinese users. While implementing the language toggles in the UI, I noticed that the current setup in `arcdps-extension` was missing the distinct asset mapping/slots for TChinese, which makes it tricky to achieve clean real-time toggling or dual Simplified/Traditional Chinese support alongside the other native languages.

By adding these changes here, it allows down-stream plugins like **Boon Table** to cleanly integrate TChinese translations without breaking the `magic_enum` structures or relying on unsafe explicit index overrides.

Thank you for maintaining this awesome extension library! Let me know if any adjustments are needed.